### PR TITLE
fix(dart): record receiver method calls so private helpers aren't flagged dead (#155)

### DIFF
--- a/src/extraction/dart_extractor.rs
+++ b/src/extraction/dart_extractor.rs
@@ -1666,6 +1666,38 @@ impl DartExtractor {
                                 });
                             }
                         }
+                    } else if let Some(uas) =
+                        Self::find_child_by_kind(child, "unconditional_assignable_selector")
+                    {
+                        // tree-sitter-dart 0.2 splits a receiver method call
+                        // `recv.method(args)` into two *sibling* selectors: one
+                        // holding the member name (`.method`) and a separate one
+                        // holding the call's `argument_part`. The branch above
+                        // only fires when both live in one selector (the 0.1
+                        // shape), so member calls like `this._parseItem(s)` or
+                        // `obj.method(s)` produced no Calls edge (#155). Detect a
+                        // name-only selector whose next named sibling is the
+                        // argument selector and emit the call here.
+                        let is_call = child
+                            .next_named_sibling()
+                            .filter(|s| s.kind() == "selector")
+                            .is_some_and(|s| {
+                                Self::find_child_by_kind(s, "argument_part").is_some()
+                                    || Self::find_child_by_kind(s, "arguments").is_some()
+                            });
+                        if is_call {
+                            if let Some(ident) = Self::find_child_by_kind(uas, "identifier") {
+                                let callee_name = state.node_text(ident);
+                                state.unresolved_refs.push(UnresolvedRef {
+                                    from_node_id: fn_node_id.to_string(),
+                                    reference_name: callee_name,
+                                    reference_kind: EdgeKind::Calls,
+                                    line: child.start_position().row as u32,
+                                    column: child.start_position().column as u32,
+                                    file_path: state.file_path.clone(),
+                                });
+                            }
+                        }
                     }
                     // Also recurse into selectors for nested calls in arguments.
                     Self::extract_call_sites(state, child, fn_node_id);

--- a/tests/dart_extraction_test.rs
+++ b/tests/dart_extraction_test.rs
@@ -302,6 +302,29 @@ fn test_dart_call_site_tracking() {
 }
 
 #[test]
+fn test_dart_receiver_method_call_tracking() {
+    // tree-sitter-dart 0.2 splits `recv.method(args)` into two sibling
+    // selectors (member name, then argument_part). Member calls such as
+    // `this._parseItem(s)` and `obj.method(s)` must still emit Calls refs
+    // so private helpers aren't reported as dead introductions (#155).
+    let result = extract(
+        "class Parser {\n  int parse(String s) {\n    return this._parseItem(s);\n  }\n  int _parseItem(String s) => s.length;\n}",
+    );
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let calls: Vec<_> = result
+        .unresolved_refs
+        .iter()
+        .filter(|r| r.reference_kind == EdgeKind::Calls)
+        .map(|r| r.reference_name.as_str())
+        .collect();
+    assert!(
+        calls.contains(&"_parseItem"),
+        "expected a Calls ref to '_parseItem' via this., got {:?}",
+        calls
+    );
+}
+
+#[test]
 fn test_dart_contains_edges() {
     let result = extract("class Foo {\n  void bar() {}\n}");
     assert!(result.errors.is_empty(), "errors: {:?}", result.errors);


### PR DESCRIPTION
## Summary

Fixes #155. `tokensave_simplify_scan` reported private Dart instance helpers (e.g. `_parseItem`) as dead introductions with no incoming edges, even when called from other methods in the same class.

## Root cause

Not a symbol-resolution issue — a **call-edge extraction gap**. tree-sitter-dart 0.2 represents a receiver method call `recv.method(args)` (including the idiomatic `this._parseItem(s)`) as **two sibling `selector` nodes**: one holding the member name (`._parseItem`), a separate one holding the `argument_part`. The selector handler only emitted a `Calls` ref when the name and `argument_part` lived in the *same* selector (the 0.1 shape), so every `this.x()` / `obj.x()` call produced no call edge. Private helpers reached only via `this.` then showed zero incoming edges and were flagged dead.

This also fixes a broader latent gap: **all** receiver method calls (`xs.map(...)`, `.toList()`) were previously missed, not just private ones.

## Changes
- Handle the name-only selector whose next sibling selector carries the arguments, in `extract_call_sites`.
- Regression test `test_dart_receiver_method_call_tracking`.

Full Dart extraction suite passes; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)