### PR TITLE
feat(agent): add Factory Droid agent integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Factory Droid agent integration (`tokensave install --agent droid`).** Registers the tokensave MCP server in `~/.factory/mcp.json` under `mcpServers.tokensave` (stdio transport) and appends the tokensave rules to `~/.factory/AGENTS.md`. `--local` writes `<project>/.factory/mcp.json` and a repo-root `<project>/AGENTS.md`. Auto-detected by `tokensave install` (and `reinstall`/`doctor`) when `~/.factory` exists.
 
 ## [7.0.3] - 2026-06-30
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ AI coding agents waste tokens exploring codebases. Every grep, glob, and file re
 | **Smart Context Building** | **Semantic Search** | **Impact Analysis** |
 | One tool call returns everything the agent needs -- entry points, related symbols, and code snippets. | Find code by meaning, not just text. Search for "authentication" and find `login`, `validateToken`, `AuthService`. | Know exactly what breaks before you change it. Trace callers, callees, and the full impact radius of any symbol. |
 | **80+ MCP Tools** | **50+ Languages** | **12+ Agent Integrations** |
-| From call graph traversal to dead code detection, atomic edit primitives, code-health metrics, test mapping, and complexity analysis. | Rust, Go, Java, Python, TypeScript, C, C++, Swift, Svelte, Astro, and 42 more including WGSL/HLSL/Metal shaders and Markdown. Three tiers (lite/medium/full) control binary size. | Claude Code, Codex CLI, Gemini CLI, Qwen Code, Kiro, Cursor, OpenCode, Copilot, Cline, Roo Code, Zed, Antigravity, Kilo CLI, Kimi CLI, Mistral Vibe, Grok Build. |
+| From call graph traversal to dead code detection, atomic edit primitives, code-health metrics, test mapping, and complexity analysis. | Rust, Go, Java, Python, TypeScript, C, C++, Swift, Svelte, Astro, and 42 more including WGSL/HLSL/Metal shaders and Markdown. Three tiers (lite/medium/full) control binary size. | Claude Code, Codex CLI, Gemini CLI, Qwen Code, Kiro, Cursor, OpenCode, Copilot, Cline, Roo Code, Zed, Antigravity, Kilo CLI, Kimi CLI, Mistral Vibe, Grok Build, Factory Droid. |
 | **Multi-Branch Indexing (opt-in)** | **100% Local** | **Always Fresh** |
 | Optional per-branch databases. Cross-branch diff and search without switching your checkout. | No data leaves your machine. No API keys. No external services. Everything runs on a local libSQL database. | On-demand staleness check on every MCP call (30 s cooldown) plus catch-up sync when the server connects. Multi-agent work is expected to use git worktrees — each agent gets its own checkout and the index diverges are merged by git, not by a file watcher. |
 | **Subprocess-Isolated Extraction** | **Code-Health Analytics** | **Atomic Edit Primitives** |
@@ -125,6 +125,7 @@ tokensave install --agent cline           # Cline
 tokensave install --agent codex           # OpenAI Codex CLI
 tokensave install --agent copilot         # GitHub Copilot
 tokensave install --agent cursor          # Cursor
+tokensave install --agent droid           # Factory Droid
 tokensave install --agent gemini          # Gemini CLI
 tokensave install --agent kilo            # Kilo CLI
 tokensave install --agent kiro            # AWS Kiro
@@ -792,7 +793,7 @@ tokensave is a ground-up Rust rewrite of [CodeGraph](https://www.npmjs.com/packa
 | **Install** | `brew install`, `cargo install`, `scoop install` | `npx @colbymchenry/codegraph` |
 | **Languages** | 50+ (3 tiers: lite/medium/full) | 19+ |
 | **MCP tools** | 80+ | 9 |
-| **Agent integrations** | 12+ (Claude, Codex, Gemini, Qwen, OpenCode, Cursor, Cline, Copilot, Roo Code, Zed, Antigravity, Kilo, Kiro, Kimi, Vibe, Grok) | 1 (Claude Code) |
+| **Agent integrations** | 12+ (Claude, Codex, Gemini, Qwen, OpenCode, Cursor, Cline, Copilot, Roo Code, Zed, Antigravity, Kilo, Kiro, Kimi, Vibe, Grok, Factory Droid) | 1 (Claude Code) |
 | **Index freshness** | On-demand staleness check on every MCP call; catch-up sync on connect; multi-agent work expected to use git worktrees | Native OS-level file watcher (FSEvents/inotify/ReadDirectoryChangesW, 2 s debounce); catch-up sync on connect |
 | **Multi-branch indexing** | Yes, opt-in (per-branch DBs, cross-branch diff/search) | No |
 | **Complexity metrics** | AST-extracted (branches, loops, nesting depth, cyclomatic & cognitive complexity, Halstead, maintainability index, CRAP) | No |

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -181,7 +181,7 @@ This is the default. It registers the MCP server in `~/.claude/settings.json`, g
 
 ### Other agents
 
-Tokensave supports fourteen agents. Pass `--agent` to install for a specific one:
+Tokensave supports many agents. Pass `--agent` to install for a specific one:
 
 ```bash
 tokensave install --agent claude      # Claude Code (default)
@@ -191,6 +191,7 @@ tokensave install --agent gemini      # Gemini CLI
 tokensave install --agent qwen        # Qwen Code
 tokensave install --agent copilot     # GitHub Copilot CLI
 tokensave install --agent cursor      # Cursor
+tokensave install --agent droid       # Factory Droid
 tokensave install --agent zed         # Zed
 tokensave install --agent cline       # Cline
 tokensave install --agent roo-code    # Roo Code

--- a/src/agents/droid.rs
+++ b/src/agents/droid.rs
@@ -1,0 +1,355 @@
+// Rust guideline compliant 2026-07-02
+//! Factory Droid agent integration.
+//!
+//! Handles registration of the tokensave MCP server in Factory Droid's MCP
+//! config (`~/.factory/mcp.json` globally, `<project>/.factory/mcp.json` for
+//! `--local`) under the `mcpServers.tokensave` key, and prompt rules via
+//! `AGENTS.md` (`~/.factory/AGENTS.md` globally, `<project>/AGENTS.md` for
+//! `--local`). Factory Droid has no hook system or declarative tool
+//! permissions — it uses interactive runtime approval.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use serde_json::json;
+
+use crate::errors::{Result, TokenSaveError};
+
+use super::{
+    backup_and_write_json, backup_config_file, load_json_file, load_json_file_strict,
+    safe_write_json_file, AgentIntegration, DoctorCounters, HealthcheckContext, InstallContext,
+    InstallScope,
+};
+
+/// Factory Droid agent.
+pub struct DroidIntegration;
+
+impl AgentIntegration for DroidIntegration {
+    fn name(&self) -> &'static str {
+        "Factory Droid"
+    }
+
+    fn id(&self) -> &'static str {
+        "droid"
+    }
+
+    fn supports_local(&self) -> bool {
+        true
+    }
+
+    fn install(&self, ctx: &InstallContext) -> Result<()> {
+        let mcp_path = droid_mcp_path_for(ctx);
+        install_mcp_server(&mcp_path, &ctx.tokensave_bin)?;
+
+        let agents_md = droid_agents_md_for(ctx);
+        install_prompt_rules(&agents_md)?;
+
+        eprintln!();
+        eprintln!("Setup complete. Next steps:");
+        eprintln!("  1. cd into your project and run: tokensave init");
+        eprintln!("  2. Start a new droid session — tokensave tools are now available");
+        Ok(())
+    }
+
+    fn uninstall(&self, ctx: &InstallContext) -> Result<()> {
+        let mcp_path = droid_mcp_path_for(ctx);
+        uninstall_mcp_server(&mcp_path);
+
+        let agents_md = droid_agents_md_for(ctx);
+        uninstall_prompt_rules(&agents_md);
+
+        eprintln!();
+        eprintln!("Uninstall complete. Tokensave has been removed from Factory Droid.");
+        eprintln!("Start a new droid session for changes to take effect.");
+        Ok(())
+    }
+
+    fn healthcheck(&self, dc: &mut DoctorCounters, ctx: &HealthcheckContext) {
+        eprintln!("\n\x1b[1mFactory Droid integration\x1b[0m");
+        doctor_check_config(dc, &ctx.home);
+        doctor_check_prompt(dc, &ctx.home);
+    }
+
+    fn is_detected(&self, home: &Path) -> bool {
+        home.join(".factory").is_dir()
+    }
+
+    fn primary_config_path(&self, home: &Path) -> Option<PathBuf> {
+        Some(droid_mcp_path(home))
+    }
+
+    fn has_tokensave(&self, home: &Path) -> bool {
+        let mcp_path = droid_mcp_path(home);
+        if !mcp_path.exists() {
+            return false;
+        }
+        let json = load_json_file(&mcp_path);
+        json.get("mcpServers")
+            .and_then(|v| v.get("tokensave"))
+            .is_some()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Config path resolution
+// ---------------------------------------------------------------------------
+
+/// Global Factory Droid MCP config path (`~/.factory/mcp.json`).
+fn droid_mcp_path(home: &Path) -> PathBuf {
+    home.join(".factory/mcp.json")
+}
+
+/// mcp.json path for this install: `~/.factory/mcp.json` globally, or
+/// `<project>/.factory/mcp.json` for `--local` (same relative layout).
+fn droid_mcp_path_for(ctx: &InstallContext) -> PathBuf {
+    ctx.base_dir().join(".factory/mcp.json")
+}
+
+/// AGENTS.md path for this install: `~/.factory/AGENTS.md` globally, or
+/// `<project>/AGENTS.md` for `--local` (Factory reads a repo-root AGENTS.md).
+fn droid_agents_md_for(ctx: &InstallContext) -> PathBuf {
+    match &ctx.scope {
+        InstallScope::Global => ctx.home.join(".factory/AGENTS.md"),
+        InstallScope::Local { project_path } => project_path.join("AGENTS.md"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Install helpers
+// ---------------------------------------------------------------------------
+
+/// Register MCP server in mcp.json.
+///
+/// Safety: creates a `.bak` backup before writing and restores it on any
+/// error. Uses strict JSON parsing so an existing file with invalid syntax
+/// is never silently replaced with an empty object.
+fn install_mcp_server(mcp_path: &Path, tokensave_bin: &str) -> Result<()> {
+    if let Some(parent) = mcp_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+
+    let backup = backup_config_file(mcp_path)?;
+    let mut settings = match load_json_file_strict(mcp_path) {
+        Ok(v) => v,
+        Err(e) => {
+            if let Some(ref b) = backup {
+                eprintln!("  Backup preserved at: {}", b.display());
+            }
+            return Err(e);
+        }
+    };
+
+    settings["mcpServers"]["tokensave"] = json!({
+        "type": "stdio",
+        "command": tokensave_bin,
+        "args": ["serve"]
+    });
+
+    safe_write_json_file(mcp_path, &settings, backup.as_deref())?;
+    eprintln!(
+        "\x1b[32m✔\x1b[0m Added tokensave MCP server to {}",
+        mcp_path.display()
+    );
+    Ok(())
+}
+
+/// Append prompt rules to AGENTS.md (idempotent).
+fn install_prompt_rules(agents_md: &Path) -> Result<()> {
+    let marker = "## Prefer tokensave MCP tools";
+    let existing = if agents_md.exists() {
+        std::fs::read_to_string(agents_md).unwrap_or_default()
+    } else {
+        String::new()
+    };
+    if existing.contains(marker) {
+        eprintln!("  AGENTS.md already contains tokensave rules, skipping");
+        return Ok(());
+    }
+    if let Some(parent) = agents_md.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(agents_md)
+        .map_err(|e| TokenSaveError::Config {
+            message: format!("failed to open AGENTS.md: {e}"),
+        })?;
+    write!(
+        f,
+        "\n{marker}\n\n\
+        Before reading source files or scanning the codebase, use the tokensave MCP tools \
+        (`tokensave_context`, `tokensave_search`, `tokensave_callers`, `tokensave_callees`, \
+        `tokensave_impact`, `tokensave_node`, `tokensave_files`, `tokensave_affected`). \
+        They provide instant semantic results from a pre-built knowledge graph and are \
+        faster than file reads.\n\n\
+        If a code analysis question cannot be fully answered by tokensave MCP tools, \
+        try querying the SQLite database directly at `.tokensave/tokensave.db` \
+        (tables: `nodes`, `edges`, `files`). Use SQL to answer complex structural queries \
+        that go beyond what the built-in tools expose.\n\n\
+        If you discover a gap where an extractor, schema, or tokensave tool could be \
+        improved to answer a question natively, propose to the user that they open an issue \
+        at https://github.com/aovestdipaperino/tokensave describing the limitation. \
+        **Remind the user to strip any sensitive or proprietary code from the bug description \
+        before submitting.**\n"
+    )
+    .ok();
+    eprintln!(
+        "\x1b[32m✔\x1b[0m Appended tokensave rules to {}",
+        agents_md.display()
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Uninstall helpers
+// ---------------------------------------------------------------------------
+
+/// Remove the tokensave MCP server entry from mcp.json.
+fn uninstall_mcp_server(mcp_path: &Path) {
+    if !mcp_path.exists() {
+        eprintln!("  {} not found, skipping", mcp_path.display());
+        return;
+    }
+
+    let Ok(contents) = std::fs::read_to_string(mcp_path) else {
+        return;
+    };
+    let Ok(mut settings) = serde_json::from_str::<serde_json::Value>(&contents) else {
+        return;
+    };
+
+    let Some(servers) = settings
+        .get_mut("mcpServers")
+        .and_then(|v| v.as_object_mut())
+    else {
+        eprintln!(
+            "  No tokensave MCP server in {}, skipping",
+            mcp_path.display()
+        );
+        return;
+    };
+
+    if servers.remove("tokensave").is_none() {
+        eprintln!(
+            "  No tokensave MCP server in {}, skipping",
+            mcp_path.display()
+        );
+        return;
+    }
+
+    let is_empty = settings.as_object().is_some_and(|o| {
+        o.iter()
+            .all(|(k, v)| k == "mcpServers" && v.as_object().is_some_and(serde_json::Map::is_empty))
+    });
+
+    if is_empty {
+        std::fs::remove_file(mcp_path).ok();
+        eprintln!(
+            "\x1b[32m✔\x1b[0m Removed {} (was empty)",
+            mcp_path.display()
+        );
+    } else if backup_and_write_json(mcp_path, &settings) {
+        eprintln!(
+            "\x1b[32m✔\x1b[0m Removed tokensave MCP server from {}",
+            mcp_path.display()
+        );
+    }
+}
+
+/// Remove tokensave rules from AGENTS.md.
+fn uninstall_prompt_rules(agents_md: &Path) {
+    if !agents_md.exists() {
+        return;
+    }
+    let Ok(contents) = std::fs::read_to_string(agents_md) else {
+        return;
+    };
+    if !contents.contains("tokensave") {
+        eprintln!("  AGENTS.md does not contain tokensave rules, skipping");
+        return;
+    }
+    let marker = "## Prefer tokensave MCP tools";
+    let Some(start) = contents.find(marker) else {
+        return;
+    };
+    let after_marker = start + marker.len();
+    let end = contents[after_marker..]
+        .find("\n## ")
+        .map_or(contents.len(), |pos| after_marker + pos);
+    let mut new_contents = String::new();
+    new_contents.push_str(contents[..start].trim_end());
+    let remainder = &contents[end..];
+    if !remainder.is_empty() {
+        new_contents.push_str("\n\n");
+        new_contents.push_str(remainder.trim_start());
+    }
+    let new_contents = new_contents.trim().to_string();
+    if new_contents.is_empty() {
+        std::fs::remove_file(agents_md).ok();
+        eprintln!(
+            "\x1b[32m✔\x1b[0m Removed {} (was empty)",
+            agents_md.display()
+        );
+    } else {
+        std::fs::write(agents_md, format!("{new_contents}\n")).ok();
+        eprintln!(
+            "\x1b[32m✔\x1b[0m Removed tokensave rules from {}",
+            agents_md.display()
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Healthcheck helpers
+// ---------------------------------------------------------------------------
+
+/// Check mcp.json has tokensave registered.
+fn doctor_check_config(dc: &mut DoctorCounters, home: &Path) {
+    let mcp_path = droid_mcp_path(home);
+    if !mcp_path.exists() {
+        dc.warn(&format!(
+            "{} not found — run `tokensave install --agent droid` if you use Factory Droid",
+            mcp_path.display()
+        ));
+        return;
+    }
+
+    let config = load_json_file(&mcp_path);
+    let mcp_entry = config.get("mcpServers").and_then(|v| v.get("tokensave"));
+    if mcp_entry.and_then(|v| v.as_object()).is_none() {
+        dc.fail(&format!(
+            "MCP server NOT registered in {} — run `tokensave install --agent droid`",
+            mcp_path.display()
+        ));
+        return;
+    }
+    dc.pass(&format!("MCP server registered in {}", mcp_path.display()));
+
+    let args = mcp_entry
+        .and_then(|v| v.get("args"))
+        .and_then(|v| v.as_array());
+    let has_serve = args.is_some_and(|arr| arr.iter().any(|v| v.as_str() == Some("serve")));
+    if has_serve {
+        dc.pass("MCP server args include \"serve\"");
+    } else {
+        dc.fail("MCP server args missing \"serve\" — run `tokensave install --agent droid`");
+    }
+}
+
+/// Check AGENTS.md contains tokensave rules.
+fn doctor_check_prompt(dc: &mut DoctorCounters, home: &Path) {
+    let agents_md = home.join(".factory/AGENTS.md");
+    if agents_md.exists() {
+        let has_rules = std::fs::read_to_string(&agents_md)
+            .unwrap_or_default()
+            .contains("tokensave");
+        if has_rules {
+            dc.pass("AGENTS.md contains tokensave rules");
+        } else {
+            dc.fail("AGENTS.md missing tokensave rules — run `tokensave install --agent droid`");
+        }
+    } else {
+        dc.warn("AGENTS.md does not exist");
+    }
+}

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -12,6 +12,7 @@ pub mod cline;
 pub mod codex;
 pub mod copilot;
 pub mod cursor;
+pub mod droid;
 pub mod gemini;
 pub mod grok;
 pub mod kilo;
@@ -38,6 +39,7 @@ pub use cline::ClineIntegration;
 pub use codex::CodexIntegration;
 pub use copilot::CopilotIntegration;
 pub use cursor::CursorIntegration;
+pub use droid::DroidIntegration;
 pub use gemini::GeminiIntegration;
 pub use grok::GrokIntegration;
 pub use kilo::KiloIntegration;
@@ -158,6 +160,7 @@ pub fn get_integration(id: &str) -> Result<Box<dyn AgentIntegration>> {
         "qwen" => Ok(Box::new(QwenIntegration)),
         "copilot" => Ok(Box::new(CopilotIntegration)),
         "cursor" => Ok(Box::new(CursorIntegration)),
+        "droid" => Ok(Box::new(DroidIntegration)),
         "zed" => Ok(Box::new(ZedIntegration)),
         "cline" => Ok(Box::new(ClineIntegration)),
         "roo-code" => Ok(Box::new(RooCodeIntegration)),
@@ -187,6 +190,7 @@ pub fn all_integrations() -> Vec<Box<dyn AgentIntegration>> {
         Box::new(QwenIntegration),
         Box::new(CopilotIntegration),
         Box::new(CursorIntegration),
+        Box::new(DroidIntegration),
         Box::new(ZedIntegration),
         Box::new(ClineIntegration),
         Box::new(RooCodeIntegration),
@@ -210,6 +214,7 @@ pub fn available_integrations() -> Vec<&'static str> {
         "qwen",
         "copilot",
         "cursor",
+        "droid",
         "zed",
         "cline",
         "roo-code",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -100,7 +100,7 @@ pub enum Commands {
         git_hook: GitHookMode,
         /// Install into the current project's config instead of the user's
         /// global config. Only supported for agents with a project-scoped
-        /// config (claude, cursor, gemini, zed, opencode, roo-code, kiro).
+        /// config (claude, cursor, droid, gemini, zed, opencode, roo-code, kiro).
         #[arg(long)]
         local: bool,
     },

--- a/tests/agent_test.rs
+++ b/tests/agent_test.rs
@@ -10,7 +10,7 @@ use tokensave::agents::*;
 #[test]
 fn test_get_all_integrations() {
     let all = all_integrations();
-    assert_eq!(all.len(), 17);
+    assert_eq!(all.len(), 18);
 }
 
 #[test]
@@ -23,6 +23,7 @@ fn test_available_integrations() {
     assert!(ids.contains(&"qwen"));
     assert!(ids.contains(&"opencode"));
     assert!(ids.contains(&"cursor"));
+    assert!(ids.contains(&"droid"));
     assert!(ids.contains(&"zed"));
     assert!(ids.contains(&"cline"));
     assert!(ids.contains(&"roo-code"));
@@ -34,7 +35,7 @@ fn test_available_integrations() {
     assert!(ids.contains(&"grok"));
     assert!(ids.contains(&"pi"));
     assert!(ids.contains(&"qwen"));
-    assert_eq!(ids.len(), 17);
+    assert_eq!(ids.len(), 18);
 }
 
 #[test]
@@ -47,6 +48,7 @@ fn test_get_integration_valid() {
         "qwen",
         "copilot",
         "cursor",
+        "droid",
         "zed",
         "cline",
         "roo-code",
@@ -93,6 +95,7 @@ fn test_agent_names_are_human_readable() {
         ("qwen", "Qwen Code"),
         ("opencode", "OpenCode"),
         ("cursor", "Cursor"),
+        ("droid", "Factory Droid"),
         ("zed", "Zed"),
         ("cline", "Cline"),
         ("roo-code", "Roo Code"),

--- a/tests/droid_agent_test.rs
+++ b/tests/droid_agent_test.rs
@@ -1,0 +1,405 @@
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+use tokensave::agents::{
+    expected_tool_perms, AgentIntegration, DoctorCounters, DroidIntegration, HealthcheckContext,
+    InstallContext, InstallScope,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_ctx(home: &Path) -> InstallContext {
+    InstallContext {
+        home: home.to_path_buf(),
+        tokensave_bin: "/usr/local/bin/tokensave".to_string(),
+        tool_permissions: expected_tool_perms(),
+        scope: InstallScope::Global,
+    }
+}
+
+fn make_local_ctx(home: &Path, project: &Path) -> InstallContext {
+    InstallContext {
+        home: home.to_path_buf(),
+        tokensave_bin: "/usr/local/bin/tokensave".to_string(),
+        tool_permissions: expected_tool_perms(),
+        scope: InstallScope::Local {
+            project_path: project.to_path_buf(),
+        },
+    }
+}
+
+fn read_json(path: &Path) -> serde_json::Value {
+    let contents = std::fs::read_to_string(path).unwrap();
+    serde_json::from_str(&contents).unwrap()
+}
+
+fn mcp_path(home: &Path) -> PathBuf {
+    home.join(".factory/mcp.json")
+}
+
+fn agents_md_path(home: &Path) -> PathBuf {
+    home.join(".factory/AGENTS.md")
+}
+
+// ===========================================================================
+// Install content verification
+// ===========================================================================
+
+#[test]
+fn test_install_creates_mcp_json() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_ctx(home);
+    DroidIntegration.install(&ctx).unwrap();
+
+    let path = mcp_path(home);
+    assert!(path.exists(), "mcp.json should be created");
+
+    let config = read_json(&path);
+    let ts = &config["mcpServers"]["tokensave"];
+    assert!(ts.is_object(), "mcpServers.tokensave should be an object");
+    assert_eq!(
+        ts["type"].as_str().unwrap(),
+        "stdio",
+        "type should be stdio"
+    );
+    assert_eq!(
+        ts["command"].as_str().unwrap(),
+        "/usr/local/bin/tokensave",
+        "command should be the tokensave binary path"
+    );
+    let args: Vec<&str> = ts["args"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(args, vec!["serve"], "args should be [\"serve\"]");
+}
+
+#[test]
+fn test_install_appends_prompt_rules() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_ctx(home);
+    DroidIntegration.install(&ctx).unwrap();
+
+    let rules = std::fs::read_to_string(agents_md_path(home)).unwrap();
+    assert!(
+        rules.contains("## Prefer tokensave MCP tools"),
+        "AGENTS.md should contain the tokensave rules marker"
+    );
+}
+
+#[test]
+fn test_install_preserves_existing_server() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+
+    let path = mcp_path(home);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &path,
+        r#"{"someSetting": true, "mcpServers": {"other-tool": {"command": "other", "args": ["run"]}}}"#,
+    )
+    .unwrap();
+
+    let ctx = make_ctx(home);
+    DroidIntegration.install(&ctx).unwrap();
+
+    let config = read_json(&path);
+    assert!(
+        config["someSetting"].as_bool().unwrap(),
+        "unrelated top-level key should be preserved"
+    );
+    assert!(
+        config["mcpServers"]["other-tool"].is_object(),
+        "existing MCP server should be preserved"
+    );
+    assert!(
+        config["mcpServers"]["tokensave"].is_object(),
+        "tokensave should be added"
+    );
+}
+
+#[test]
+fn test_install_idempotent() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_ctx(home);
+
+    DroidIntegration.install(&ctx).unwrap();
+    DroidIntegration.install(&ctx).unwrap();
+
+    let config = read_json(&mcp_path(home));
+    let servers = config["mcpServers"].as_object().unwrap();
+    let ts_count = servers.keys().filter(|k| *k == "tokensave").count();
+    assert_eq!(ts_count, 1, "tokensave should appear exactly once");
+
+    let rules = std::fs::read_to_string(agents_md_path(home)).unwrap();
+    assert_eq!(
+        rules.matches("## Prefer tokensave MCP tools").count(),
+        1,
+        "rules block should appear exactly once"
+    );
+}
+
+#[test]
+fn test_primary_config_path_matches_install_target() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_ctx(home);
+    DroidIntegration.install(&ctx).unwrap();
+
+    let primary = DroidIntegration.primary_config_path(home).unwrap();
+    assert!(
+        primary.exists(),
+        "primary_config_path should exist after install"
+    );
+    assert_eq!(
+        primary,
+        mcp_path(home),
+        "primary_config_path should match where install wrote"
+    );
+}
+
+#[test]
+fn test_local_install_targets_project() {
+    let home_dir = TempDir::new().unwrap();
+    let proj_dir = TempDir::new().unwrap();
+    let home = home_dir.path();
+    let project = proj_dir.path();
+
+    let ctx = make_local_ctx(home, project);
+    DroidIntegration.install(&ctx).unwrap();
+
+    assert!(
+        project.join(".factory/mcp.json").exists(),
+        "--local should write <project>/.factory/mcp.json"
+    );
+    assert!(
+        project.join("AGENTS.md").exists(),
+        "--local should write <project>/AGENTS.md"
+    );
+    assert!(
+        !mcp_path(home).exists(),
+        "global ~/.factory/mcp.json should not be written for --local"
+    );
+}
+
+// ===========================================================================
+// Uninstall verification
+// ===========================================================================
+
+#[test]
+fn test_uninstall_removes_only_tokensave() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+
+    let path = mcp_path(home);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &path,
+        r#"{"mcpServers": {"other-tool": {"command": "other", "args": ["run"]}}}"#,
+    )
+    .unwrap();
+
+    let ctx = make_ctx(home);
+    DroidIntegration.install(&ctx).unwrap();
+    DroidIntegration.uninstall(&ctx).unwrap();
+
+    assert!(
+        path.exists(),
+        "config should still exist because another server remains"
+    );
+    let config = read_json(&path);
+    assert!(
+        config["mcpServers"]["other-tool"].is_object(),
+        "other server should be preserved"
+    );
+    assert!(
+        config
+            .get("mcpServers")
+            .and_then(|v| v.get("tokensave"))
+            .is_none(),
+        "tokensave should be removed"
+    );
+}
+
+#[test]
+fn test_uninstall_removes_empty_config_file() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_ctx(home);
+
+    DroidIntegration.install(&ctx).unwrap();
+    DroidIntegration.uninstall(&ctx).unwrap();
+
+    assert!(
+        !mcp_path(home).exists(),
+        "mcp.json should be deleted when tokensave was the only entry"
+    );
+}
+
+#[test]
+fn test_uninstall_removes_prompt_rules() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_ctx(home);
+
+    DroidIntegration.install(&ctx).unwrap();
+    DroidIntegration.uninstall(&ctx).unwrap();
+
+    let path = agents_md_path(home);
+    if path.exists() {
+        let rules = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            !rules.contains("tokensave"),
+            "tokensave rules should be removed from AGENTS.md"
+        );
+    }
+}
+
+#[test]
+fn test_uninstall_preserves_other_agents_md_content() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+
+    let path = agents_md_path(home);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, "# My rules\n\nKeep this.\n").unwrap();
+
+    let ctx = make_ctx(home);
+    DroidIntegration.install(&ctx).unwrap();
+    DroidIntegration.uninstall(&ctx).unwrap();
+
+    let rules = std::fs::read_to_string(&path).unwrap();
+    assert!(rules.contains("Keep this."), "user content should survive");
+    assert!(
+        !rules.contains("tokensave"),
+        "tokensave rules should be removed"
+    );
+}
+
+#[test]
+fn test_uninstall_without_install_does_not_crash() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_ctx(home);
+    DroidIntegration.uninstall(&ctx).unwrap();
+}
+
+// ===========================================================================
+// Healthcheck verification
+// ===========================================================================
+
+#[test]
+fn test_healthcheck_clean_install_no_issues() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_ctx(home);
+    DroidIntegration.install(&ctx).unwrap();
+
+    let mut dc = DoctorCounters::new();
+    let hctx = HealthcheckContext {
+        home: home.to_path_buf(),
+        project_path: home.to_path_buf(),
+    };
+    DroidIntegration.healthcheck(&mut dc, &hctx);
+    assert_eq!(dc.issues, 0, "clean droid install should have no issues");
+}
+
+#[test]
+fn test_healthcheck_missing_config_produces_warning() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+
+    let mut dc = DoctorCounters::new();
+    let hctx = HealthcheckContext {
+        home: home.to_path_buf(),
+        project_path: home.to_path_buf(),
+    };
+    DroidIntegration.healthcheck(&mut dc, &hctx);
+    assert!(
+        dc.warnings > 0 || dc.issues > 0,
+        "healthcheck on empty dir should report warnings or issues"
+    );
+}
+
+#[test]
+fn test_healthcheck_detects_missing_mcp_entry() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+
+    let path = mcp_path(home);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, r#"{"mcpServers": {}}"#).unwrap();
+
+    let mut dc = DoctorCounters::new();
+    let hctx = HealthcheckContext {
+        home: home.to_path_buf(),
+        project_path: home.to_path_buf(),
+    };
+    DroidIntegration.healthcheck(&mut dc, &hctx);
+    assert!(dc.issues > 0, "healthcheck should detect missing MCP entry");
+}
+
+// ===========================================================================
+// is_detected / has_tokensave
+// ===========================================================================
+
+#[test]
+fn test_is_detected_empty_home() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    assert!(
+        !DroidIntegration.is_detected(home),
+        "should not be detected on empty home"
+    );
+}
+
+#[test]
+fn test_is_detected_with_factory_dir() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    std::fs::create_dir_all(home.join(".factory")).unwrap();
+    assert!(
+        DroidIntegration.is_detected(home),
+        "should be detected when ~/.factory exists"
+    );
+}
+
+#[test]
+fn test_has_tokensave_before_and_after_install() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    assert!(
+        !DroidIntegration.has_tokensave(home),
+        "has_tokensave should be false before install"
+    );
+
+    let ctx = make_ctx(home);
+    DroidIntegration.install(&ctx).unwrap();
+    assert!(
+        DroidIntegration.has_tokensave(home),
+        "has_tokensave should be true after install"
+    );
+
+    DroidIntegration.uninstall(&ctx).unwrap();
+    assert!(
+        !DroidIntegration.has_tokensave(home),
+        "has_tokensave should be false after uninstall"
+    );
+}
+
+// ===========================================================================
+// Name / ID
+// ===========================================================================
+
+#[test]
+fn test_name_and_id() {
+    assert_eq!(DroidIntegration.name(), "Factory Droid");
+    assert_eq!(DroidIntegration.id(), "droid");
+}


### PR DESCRIPTION
## Summary

- Add **Factory Droid** (the `droid` CLI) as a `tokensave install --agent droid` target.
- Registers the tokensave MCP server in `~/.factory/mcp.json` and appends prompt rules to `~/.factory/AGENTS.md` (with `--local` support for project-scoped config).
- Follows the JSON-MCP + AGENTS.md pattern of OpenCode/Pi/Codex; no new dependencies.
- Solves https://github.com/aovestdipaperino/tokensave/issues/163

## Motivation

Factory Droid is a widely used agentic CLI that supports MCP servers and the AGENTS.md instruction standard, but tokensave had no integration for it. This brings Droid to parity with the other supported agents so its users get the
same code-graph tooling. 

Factory also supports Claude-style hooks; wiring those is intentionally left as a follow-up to keep this PR minimal and consistent with every other non-Claude agent. And even more, start using it asap, as I am doing locally.

## Changes

- **`src/agents/droid.rs`** (new): `DroidIntegration` implementing `AgentIntegration`:
  - MCP server written to `~/.factory/mcp.json` under `mcpServers.tokensave`   with Factory's stdio shape `{ "type": "stdio", "command": <bin>, "args": ["serve"] }`;    `--local` writes `<project>/.factory/mcp.json`.
  - Prompt rules appended to `~/.factory/AGENTS.md` (global) or a repo-root    `<project>/AGENTS.md` (`--local`), reusing the OpenCode marker/idempotency logic.
  - install/uninstall touch only the `tokensave` entry/rules block (unrelated    servers, keys, and AGENTS.md content preserved; files deleted only when empty).
  - No hooks/permissions (Factory uses runtime approval, like OpenCode/Pi).
- **`src/agents/mod.rs`**: register `droid` in the four registry sites, so  `install` / `reinstall` / `uninstall` / `doctor` / auto-detect all cover it  (all registry-driven; no per-command changes needed).
- **`src/cli.rs`**: list `droid` in the `--local` flag's project-scoped agents.
- **Docs**: `README.md` (command list + agent prose lists), `docs/USER-GUIDE.md`,  `CHANGELOG.md` (`[Unreleased]`).

## Test plan

- [x] `cargo test` passes; `tests/droid_agent_test.rs` (new, 18 tests: install/uninstall, idempotency, server/key/content preservation, `--local`,  detection, healthcheck) and `tests/agent_test.rs` (registry count + enumerations).
- [x] `cargo clippy` has no new warnings (`cargo clippy --workspace --all-targets`).
- [x] `cargo fmt --check` clean.
- [x] Tested manually: `tokensave install --agent droid`, bare `tokensave install`  (auto-detect via `~/.factory`), `doctor --agent droid`, and an uninstall  round-trip; verified `~/.factory/mcp.json` and `~/.factory/AGENTS.md`.
- [x] Tested manually: usage in a local project (`tokensave install --local --agent droid` + uninstall, verified modified files)

## Checklist

- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [x] No secrets, credentials, or `.env` files included
- [x] No breaking changes
