### PR TITLE
fix(hooks): read Claude PreToolUse event from stdin, not TOOL_INPUT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Claude Code `PreToolUse` hook never fired — the grep/Read→MCP guardrail was silently dead.** `hook_pre_tool_use` read the tool arguments from a `TOOL_INPUT` environment variable, but Claude Code delivers the hook event as JSON on **stdin** (with the tool arguments nested under `tool_input`) and sets no such variable. The decision logic was correct, but it always ran against an empty input, so every Grep/Read/Agent call was implicitly allowed and nothing redirected exploration to the tokensave MCP tools — under-reporting `tokensave monitor` savings. The handler now reads Claude's stdin contract (unwrapping the nested `tool_input`), keeps the `TOOL_INPUT` env var as a fallback for empty stdin, and preserves the existing flat-input decision logic. The sibling Kiro hooks already read stdin correctly and are unaffected.
+
 
 ## [7.0.3] - 2026-06-30
 

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -129,16 +129,37 @@ enum PatternShape {
 
 /// `PreToolUse` hook handler for Claude Code's Agent / Grep / Bash matchers.
 ///
-/// Reads the `TOOL_INPUT` environment variable (JSON), inspects the input,
-/// and prints a JSON decision to stdout. Blocks Explore agents,
-/// exploration-style prompts, and symbol-shaped grep/Grep calls against
-/// indexed code files — directing Claude to use tokensave MCP tools instead.
+/// Claude Code delivers the hook event as JSON on **stdin** with the tool
+/// arguments nested under `tool_input`; it sets no `TOOL_INPUT` env var.
+/// Reads stdin, inspects the input, and prints a JSON decision to stdout.
+/// Blocks Explore agents, exploration-style prompts, and symbol-shaped
+/// grep/Grep calls against indexed code files — directing Claude to use
+/// tokensave MCP tools instead. Falls back to the `TOOL_INPUT` env var when
+/// stdin is empty.
 pub fn hook_pre_tool_use() {
-    let tool_input = std::env::var("TOOL_INPUT").unwrap_or_default();
-    let decision = evaluate_hook_decision(&tool_input);
+    let raw = read_stdin_to_string();
+    let decision = if raw.trim().is_empty() {
+        evaluate_hook_decision(&std::env::var("TOOL_INPUT").unwrap_or_default())
+    } else {
+        evaluate_claude_pre_tool_use(&raw)
+    };
     if !decision.is_empty() {
         println!("{decision}");
     }
+}
+
+/// Parse Claude Code's `PreToolUse` stdin JSON and return the decision string.
+///
+/// Unwraps the nested `tool_input` object before delegating to
+/// [`evaluate_hook_decision`]. If the payload isn't the expected wrapper shape,
+/// falls back to treating `raw` as a flat tool-input object.
+pub fn evaluate_claude_pre_tool_use(raw: &str) -> String {
+    let tool_input = serde_json::from_str::<serde_json::Value>(raw)
+        .ok()
+        .and_then(|v| v.get("tool_input").cloned())
+        .map(|ti| ti.to_string())
+        .unwrap_or_else(|| raw.to_string());
+    evaluate_hook_decision(&tool_input)
 }
 
 /// Pure decision logic for the `PreToolUse` hook, using the real process

--- a/tests/hooks_test.rs
+++ b/tests/hooks_test.rs
@@ -1,5 +1,6 @@
 use tokensave::hooks::{
-    evaluate_hook_decision, evaluate_hook_decision_with_env, evaluate_kiro_pre_tool_use, HookEnv,
+    evaluate_claude_pre_tool_use, evaluate_hook_decision, evaluate_hook_decision_with_env,
+    evaluate_kiro_pre_tool_use, HookEnv,
 };
 
 fn env_indexed() -> HookEnv {
@@ -495,4 +496,56 @@ fn test_grep_existing_evaluate_hook_decision_still_works_for_agent() {
     let input = r#"{"subagent_type": "Explore"}"#;
     let result = evaluate_hook_decision(input);
     assert!(is_blocked(&result));
+}
+
+// ============================================================================
+// Claude Code PreToolUse stdin contract — event arrives as JSON on stdin with
+// the tool arguments nested under `tool_input` (no TOOL_INPUT env var).
+// ============================================================================
+
+#[test]
+fn test_claude_blocks_explore_agent_nested_stdin() {
+    let input = r#"{
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Agent",
+        "tool_input": {"subagent_type": "Explore", "prompt": "find files"}
+    }"#;
+    let result = evaluate_claude_pre_tool_use(input);
+    assert!(is_blocked(&result), "nested Explore agent should redirect");
+}
+
+#[test]
+fn test_claude_blocks_research_prompt_nested_stdin() {
+    let input = r#"{
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Agent",
+        "tool_input": {"prompt": "who calls the process_data function?"}
+    }"#;
+    let result = evaluate_claude_pre_tool_use(input);
+    assert!(is_blocked(&result));
+    assert!(get_block_reason(&result).contains("tokensave MCP tools"));
+}
+
+#[test]
+fn test_claude_allows_normal_tool_nested_stdin() {
+    let input = r#"{
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "cargo test"}
+    }"#;
+    let result = evaluate_claude_pre_tool_use(input);
+    assert!(result.is_empty(), "normal tool call should pass through");
+}
+
+#[test]
+fn test_claude_falls_back_to_flat_tool_input() {
+    // If the wrapper is absent, treat the payload as a flat tool_input object.
+    let input = r#"{"subagent_type": "Explore"}"#;
+    let result = evaluate_claude_pre_tool_use(input);
+    assert!(is_blocked(&result));
+}
+
+#[test]
+fn test_claude_allows_invalid_json() {
+    assert!(evaluate_claude_pre_tool_use("not json").is_empty());
 }


### PR DESCRIPTION
## Summary

_Disclaimer_ I am still surprised this is broken or a real bug, but found it early this morning and wanted to give it a try. Filled the issue and then started exploring it. Here the PR to review. I left it in draft in case I am missing something.

- Fix the Claude Code `PreToolUse` hook (`tokensave hook-pre-tool-use`), which never fired: it read tool arguments from a `TOOL_INPUT` env var that Claude Code does not set.
- The handler now reads the hook event from **stdin** (Claude's contract) and unwraps the nested `tool_input` object, restoring the grep/Read/Agent → tokensave-MCP guardrail.
- Keeps `TOOL_INPUT` as a fallback (used when stdin is empty) so nothing regresses.
- Solves https://github.com/aovestdipaperino/tokensave/issues/165

## Motivation

Closes #<ISSUE_NUMBER>.

`hook_pre_tool_use()` in `src/hooks.rs` read its input from `std::env::var("TOOL_INPUT")`. Per the official Claude Code hooks reference, Claude Code delivers each hook event as **JSON on stdin** with the tool arguments nested under a top-level `tool_input` key, and sets **no `TOOL_INPUT` environment variable**. The decision logic was correct but always ran against an empty string, so every `Grep`/`Bash grep`/`Read`/`Agent` call was implicitly allowed and nothing redirected exploration to the tokensave MCP tools. Because the hook fails open (empty output = allow), nothing visibly broke, but the token-savings guardrail was a silent no-op, and `tokensave monitor` can report 0 saved for a whole session in an initialized project.

The sibling Kiro hooks already read stdin correctly via the existing `read_stdin_to_string()` helper; only the Claude path used the env var. The other Claude hooks (`hook_prompt_submit`, `hook_stop`) read no tool input from the environment and are unaffected.

Verified against the current Claude Code hooks docs: stdin JSON, top-level `hook_event_name`/`tool_name`/`tool_input`, deny via `hookSpecificOutput.permissionDecision: "deny"`.

## Design note (narrow scope, fails open)

The decision is a **pure function of the tool-input JSON plus a cheap env snapshot** (does `.tokensave/tokensave.db` exist? is `TOKENSAVE_DISABLE_GREP_HOOK` set?). It never calls the tokensave MCP server or touches the DB, so a broken/slow tokensave cannot make the hook block. It only intercepts: an `Explore` subagent, a code-research-style Agent prompt, a symbol-shaped `Grep` on code files in an indexed project, and a `Bash` command that *starts with* `grep`/`rg`/`ag` (after `rtk`/`sudo`) matching the same. Everything else passes through, like arbitrary Bash, `git grep`, non-code greps, `files_with_matches`/`count` modes, regex sweeps, non-`Explore` sub-agents. Malformed/unexpected JSON, empty input, or a hook that errors all resolve to "allow" (fail open), so the guardrail can never wedge an agent. The deny message names the `TOKENSAVE_DISABLE_GREP_HOOK=1` escape hatch; for a `Bash` grep an agent can even set it inline on the one command (`TOKENSAVE_DISABLE_GREP_HOOK=1 grep …`) since the hook reads the Bash child's env.

## Changes

- `src/hooks.rs`:
  - `hook_pre_tool_use()` now reads stdin via `read_stdin_to_string()`; when stdin is non-empty it delegates to the new `evaluate_claude_pre_tool_use()`, otherwise it falls back to the `TOOL_INPUT` env var.
  - New pure `evaluate_claude_pre_tool_use(raw: &str) -> String` unwraps the nested `tool_input` object then delegates to the existing `evaluate_hook_decision()`; if the wrapper shape is absent it treats `raw` as a flat tool-input object.
  - `evaluate_hook_decision` / `evaluate_hook_decision_with_env` are unchanged, so all existing flat-string unit tests still apply.
- `tests/hooks_test.rs`: 5 new tests covering Claude's nested-stdin shape end-to-end (blocks Explore agent, blocks research prompt with the MCP-tools reason, allows a normal tool call, falls back to a flat `tool_input`, allows invalid JSON).
- `CHANGELOG.md`: entry under `[Unreleased]`.

## Test plan

- [x] `cargo test --test hooks_test` passes (60 tests, 5 new)
- [x] `cargo clippy --workspace --all-targets`; no new warnings from this change
- [x] Tested manually against the built binary:
  ```
  # nested stdin (Claude's real shape); now DENIES (was silent before):
  printf '{"hook_event_name":"PreToolUse","tool_name":"Grep","tool_input":{"pattern":"install_mcp_server","glob":"*.rs"}}' | tokensave hook-pre-tool-use
  # -> {"hookSpecificOutput":{...,"permissionDecision":"deny",...}}

  # env-var fallback still works:
  TOOL_INPUT='{"pattern":"install_mcp_server","glob":"*.rs"}' tokensave hook-pre-tool-use
  # -> deny JSON

  # normal tool call; allowed (no output):
  printf '{"tool_name":"Bash","tool_input":{"command":"cargo test"}}' | tokensave hook-pre-tool-use
  ```
- [x] Verified in a **real Claude Code session** (hook installed, project indexed). Asked the agent to run a Bash symbol grep without using tokensave; the tool call was **blocked pre-execution** and returned verbatim:
  > STOP: This Bash grep targets a code file in a tokensave-indexed project and the pattern `install_mcp_server` looks like a symbol name. Use tokensave_search (definition) or tokensave_callers_for (usages) instead. symbol-indexed lookups are faster and more accurate than text grep. To override for this one call, set TOKENSAVE_DISABLE_GREP_HOOK=1 in the shell.

  Re-running the same command as `TOKENSAVE_DISABLE_GREP_HOOK=1 grep -rn install_mcp_server src/` executed normally (exit 1, no matches). When blocked, the agent redirected to `tokensave_find_exact_symbol` / `tokensave_search` on its own. (Before this fix the same session performed the raw grep and recorded 0 tokens saved.)

  <img width="740" height="1052" alt="image" src="https://github.com/user-attachments/assets/31fa6954-e8c5-499c-b00c-3081ad2e6156" />

  White block is the startup message (company motd or whatever). Tested with Sonnet 5. Claude v2.1.198. Tokensave installed locally in the project where I ran `claude`.

## Checklist

- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [x] No secrets, credentials, or `.env` files included
- [x] Breaking changes documented (if any): none; env-var path retained as fallback
