### PR TITLE
ci: raise RUST_MIN_STACK to 8 MB on Windows to fix STATUS_ACCESS_VIOLATION

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
           prefix-key: v1-rust-test
 
       - name: Run tests
+        env:
+          # Match macOS/Linux's 8 MB thread-stack default; Windows MSVC's 1 MB
+          # default overflows async-heavy tests with STATUS_ACCESS_VIOLATION.
+          RUST_MIN_STACK: "8388608"
         run: cargo test --workspace
 
   clippy:


### PR DESCRIPTION
## Summary

- Raise `RUST_MIN_STACK` to 8 MB on the CI test step so the Windows runner matches macOS and Linux behavior.
- Fix `STATUS_ACCESS_VIOLATION (0xc0000005)` mid-run on `tests/context_test.rs` and other async-heavy tests in the Windows job.
- Infra-only change: no source or test modifications.
- Found here https://github.com/aovestdipaperino/tokensave/actions/runs/28743907763/job/85231401020 from the other PR https://github.com/aovestdipaperino/tokensave/pull/180

<img width="1295" height="139" alt="image" src="https://github.com/user-attachments/assets/848bfac2-9107-49f4-90ec-acb707e0b205" />


## Motivation

A subset of async-heavy tests fit comfortably on macOS and Linux's 8 MB thread stack but overflow Windows MSVC's 1 MB default, surfacing as `STATUS_ACCESS_VIOLATION` after a few tests report `ok`, before the binary exits. Upstream CI matrix shows a Windows-only failure pattern (Linux and macOS in the same matrix are `success`) replicated across some recent runs. 

Hopefully the fix is one env var on the test step. Because it is infra-only, it can ship independently of any feature work (for example, PR #180 on `rnoz/auto-track-branch`) that also surfaces this fault (where I found the CI issue).

| Run | Branch / SHA | Test Windows | Test macOS | Test Linux |
|---|---|---|---|---|
| 28743907763 | rnoz/auto-track-branch @ `3c9bf72` (PR #180) | failure | success | success |
| 28601631125 | master @ `3f801f6` (2026-07-02) | failure | success | success |
| 27870423856 | master @ `42f6937` (2026-06-20) | failure | success | success |
| 27630308516 | master @ `60a5220` (2026-06-16) | failure | success | success |

Failing job signature: `STATUS_ACCESS_VIOLATION (0xc0000005)` in `tests/context_test.rs` after several `ok` lines print but before the test binary exits. Local macOS repro of the same env setting was inconclusive on its own (the macOS pthread stack stays at 8 MB regardless of `RUST_MIN_STACK`), so empirical confirmation rests on the upstream matrix above.

## Changes

- `.github/workflows/ci.yml`: add `env: { RUST_MIN_STACK: "8388608" }` (8 MiB) on the existing `Run tests` step so the Windows runner reserves an 8 MB thread stack before launching `cargo test --workspace`. 8 MiB matches the macOS and Linux default, normalizing the matrix. Single-step change; no YAML restructure.

## Test plan

- [x] `cargo test --workspace` passes locally on macOS (~1100+ tests across 30+ test binaries, all green).
Althought not necessary for CI, still checked, just in case:
- [x] `cargo clippy --workspace --all-targets` clean.
- [x] `cargo fmt --all -- --check` clean.

## Checklist

- [x] `CHANGELOG.md` updated under `[Unreleased] ### Fixed` 
   *Not done*: this is CI only: please, let me know if it is required for CI changes as well.
- [x] No secrets, credentials, or `.env` files included.
- [x] No breaking changes documented (CI infra only; no API or behavior change for users).
