### PR TITLE
fix(gdscript): capture 3 dynamic-dispatch idioms that read as dead code

### DIFF
--- a/src/extraction/gdscript_extractor.rs
+++ b/src/extraction/gdscript_extractor.rs
@@ -777,6 +777,7 @@ impl GdScriptExtractor {
     ///   reference passed by value, the shape `BaseDatabaseCache`'s
     ///   lazy-init pattern and similar dispatch tables use. See
     ///   `extract_bare_attribute_args`.
+    ///
     /// Both were previously invisible to this extractor: a callee referenced
     /// only this way had zero recorded edges, making `tokensave_dead_code`
     /// misreport it as unreachable even though it's genuinely live.
@@ -833,10 +834,11 @@ impl GdScriptExtractor {
     /// - `X.connect(callback)` — Godot's signal-connect API; `callback` is a
     ///   bare identifier or bare dotted-attribute function reference (no call
     ///   parens) naming the handler directly.
+    ///
     /// All three were previously invisible: a handler referenced only this
     /// way showed zero incoming edges and misreported as dead code by
     /// `tokensave_dead_code`. Matching is on method name only (not receiver
-    /// type — GDScript has no static typing strong enough to verify the
+    /// type — `GDScript` has no static typing strong enough to verify the
     /// receiver really is e.g. a `Signal`), so this is a heuristic, but a
     /// narrow one: these three names are Godot-API-reserved enough in
     /// practice that a same-named unrelated user method is very unlikely.
@@ -866,7 +868,9 @@ impl GdScriptExtractor {
 
         match method.as_str() {
             "Callable" if named.len() == 2 && named[1].kind() == "string" => {
-                Self::string_literal_text(state, named[1]).into_iter().collect()
+                Self::string_literal_text(state, named[1])
+                    .into_iter()
+                    .collect()
             }
             "call_deferred" => first
                 .filter(|n| n.kind() == "string")
@@ -965,15 +969,15 @@ impl GdScriptExtractor {
     /// convention the Python/TS/JS extractors already use for the same
     /// shape. Previously only the bare method name was emitted, silently
     /// discarding the receiver — a preload-alias (`XScript.some_method()`) or
-    /// direct class_name receiver (`EquipmentDatabase.get_equipment()`) gave
+    /// direct `class_name` receiver (`EquipmentDatabase.get_equipment()`) gave
     /// the resolver no qualifier to disambiguate a same-named method
     /// elsewhere. `call` (`foo()`) carries the callee as its first named
     /// child ahead of the `arguments` field.
     fn callee_name(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         match node.kind() {
             "attribute_call" => {
-                let method = Self::find_child_by_kind(node, "identifier")
-                    .map(|n| state.node_text(n))?;
+                let method =
+                    Self::find_child_by_kind(node, "identifier").map(|n| state.node_text(n))?;
                 if let Some(receiver) = node.prev_named_sibling() {
                     let receiver_text = state.node_text(receiver);
                     if !receiver_text.is_empty() {

--- a/src/extraction/gdscript_extractor.rs
+++ b/src/extraction/gdscript_extractor.rs
@@ -764,22 +764,54 @@ impl GdScriptExtractor {
     /// unresolved `Calls` references. `GDScript` has no nested named function
     /// definitions (only `lambda` expressions), so unlike `ActionScript` there
     /// is no nested-function guard needed here.
+    ///
+    /// Two additional dynamic-dispatch idioms this codebase's style relies on
+    /// heavily are captured alongside direct calls (both verified against the
+    /// live grammar via a parse-tree dump, not inferred from node-types.json
+    /// alone, which under-documents the bare-attribute shape):
+    /// - `Callable(receiver, "method_name")` / `X.call_deferred("method_name")`
+    ///   / `X.connect(callback)` — a small, deliberately narrow allowlist of
+    ///   well-known Godot dynamic-dispatch APIs. See `dynamic_dispatch_targets`.
+    /// - A bare dotted attribute passed as a call argument with no call
+    ///   parens (`foo(bar, MyDb._load_from_registry)`) — a function
+    ///   reference passed by value, the shape `BaseDatabaseCache`'s
+    ///   lazy-init pattern and similar dispatch tables use. See
+    ///   `extract_bare_attribute_args`.
+    /// Both were previously invisible to this extractor: a callee referenced
+    /// only this way had zero recorded edges, making `tokensave_dead_code`
+    /// misreport it as unreachable even though it's genuinely live.
     fn extract_call_sites(state: &mut ExtractionState, node: TsNode<'_>, fn_id: &str) {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
             loop {
                 let child = cursor.node();
-                if matches!(child.kind(), "call" | "attribute_call") {
-                    if let Some(callee) = Self::callee_name(state, child) {
-                        state.unresolved_refs.push(UnresolvedRef {
-                            from_node_id: fn_id.to_string(),
-                            reference_name: callee,
-                            reference_kind: EdgeKind::Calls,
-                            line: child.start_position().row as u32,
-                            column: child.start_position().column as u32,
-                            file_path: state.file_path.clone(),
-                        });
+                match child.kind() {
+                    "call" | "attribute_call" => {
+                        if let Some(callee) = Self::callee_name(state, child) {
+                            state.unresolved_refs.push(UnresolvedRef {
+                                from_node_id: fn_id.to_string(),
+                                reference_name: callee,
+                                reference_kind: EdgeKind::Calls,
+                                line: child.start_position().row as u32,
+                                column: child.start_position().column as u32,
+                                file_path: state.file_path.clone(),
+                            });
+                        }
+                        for target in Self::dynamic_dispatch_targets(state, child) {
+                            state.unresolved_refs.push(UnresolvedRef {
+                                from_node_id: fn_id.to_string(),
+                                reference_name: target,
+                                reference_kind: EdgeKind::Calls,
+                                line: child.start_position().row as u32,
+                                column: child.start_position().column as u32,
+                                file_path: state.file_path.clone(),
+                            });
+                        }
                     }
+                    "arguments" => {
+                        Self::extract_bare_attribute_args(state, child, fn_id);
+                    }
+                    _ => {}
                 }
                 Self::extract_call_sites(state, child, fn_id);
                 if !cursor.goto_next_sibling() {
@@ -789,15 +821,166 @@ impl GdScriptExtractor {
         }
     }
 
+    /// Extra `Calls`-shaped targets hidden inside a small, deliberately
+    /// narrow allowlist of well-known Godot dynamic-dispatch APIs — on top
+    /// of the direct `callee_name` edge already recorded for the call site
+    /// itself (`Callable(...)`/`call_deferred(...)`/`connect(...)` are each
+    /// still recorded as an ordinary call to themselves too):
+    /// - `Callable(receiver, "method_name")` — the method is named by a
+    ///   string literal (2-arg constructor shape only).
+    /// - `X.call_deferred("method_name")` / bare `call_deferred("method_name")`
+    ///   — Godot's deferred-call API, first argument a string literal.
+    /// - `X.connect(callback)` — Godot's signal-connect API; `callback` is a
+    ///   bare identifier or bare dotted-attribute function reference (no call
+    ///   parens) naming the handler directly.
+    /// All three were previously invisible: a handler referenced only this
+    /// way showed zero incoming edges and misreported as dead code by
+    /// `tokensave_dead_code`. Matching is on method name only (not receiver
+    /// type — GDScript has no static typing strong enough to verify the
+    /// receiver really is e.g. a `Signal`), so this is a heuristic, but a
+    /// narrow one: these three names are Godot-API-reserved enough in
+    /// practice that a same-named unrelated user method is very unlikely.
+    fn dynamic_dispatch_targets(state: &ExtractionState, node: TsNode<'_>) -> Vec<String> {
+        let Some(method) = Self::find_child_by_kind(node, "identifier").map(|n| state.node_text(n))
+        else {
+            return Vec::new();
+        };
+        let Some(args) = node.child_by_field_name("arguments") else {
+            return Vec::new();
+        };
+        let mut named = Vec::new();
+        let mut cursor = args.walk();
+        if cursor.goto_first_child() {
+            loop {
+                let c = cursor.node();
+                if c.is_named() {
+                    named.push(c);
+                }
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+        }
+
+        let first: Option<TsNode<'_>> = named.first().copied();
+
+        match method.as_str() {
+            "Callable" if named.len() == 2 && named[1].kind() == "string" => {
+                Self::string_literal_text(state, named[1]).into_iter().collect()
+            }
+            "call_deferred" => first
+                .filter(|n| n.kind() == "string")
+                .and_then(|n| Self::string_literal_text(state, n))
+                .into_iter()
+                .collect(),
+            "connect" => first
+                .filter(|n| {
+                    n.kind() == "identifier"
+                        || (n.kind() == "attribute" && Self::is_bare_dotted_attribute(*n))
+                })
+                .map(|n| state.node_text(n))
+                .filter(|s| !s.is_empty())
+                .into_iter()
+                .collect(),
+            _ => Vec::new(),
+        }
+    }
+
+    /// Unquoted text of a `string` node, or `None` if empty after trimming
+    /// quotes.
+    fn string_literal_text(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
+        let raw = state.node_text(node);
+        let trimmed = raw.trim_matches(|c| c == '"' || c == '\'');
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    }
+
+    /// Scan a call's `arguments` node for bare dotted-attribute references
+    /// passed by value (no call parens) — e.g. the second argument of
+    /// `BaseDatabaseCache.get_or_create(_h, MyDb._load_from_registry)`. Each
+    /// survivor is recorded as a `Calls`-kind reference (matching the
+    /// eventual invocation semantics — it's a function value being handed
+    /// off to be called later, not data being read) so the referenced
+    /// function isn't misread as dead just because it's never *directly*
+    /// invoked at this call site.
+    fn extract_bare_attribute_args(state: &mut ExtractionState, args: TsNode<'_>, fn_id: &str) {
+        let mut cursor = args.walk();
+        if cursor.goto_first_child() {
+            loop {
+                let c = cursor.node();
+                if c.kind() == "attribute" && Self::is_bare_dotted_attribute(c) {
+                    let text = state.node_text(c);
+                    if !text.is_empty() {
+                        state.unresolved_refs.push(UnresolvedRef {
+                            from_node_id: fn_id.to_string(),
+                            reference_name: text,
+                            reference_kind: EdgeKind::Calls,
+                            line: c.start_position().row as u32,
+                            column: c.start_position().column as u32,
+                            file_path: state.file_path.clone(),
+                        });
+                    }
+                }
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+        }
+    }
+
+    /// True when `node` (an `attribute` node) is a bare dotted chain with no
+    /// trailing call/subscript — e.g. `MyDb._load_from_registry`, not
+    /// `MyDb._load_from_registry()` or `MyDb._load_from_registry[0]`.
+    /// Verified against the live grammar via a parse-tree dump: a bare `a.b`
+    /// parses as `attribute(identifier, identifier)` — two plain `identifier`
+    /// children, no `attribute_call`/`attribute_subscript` wrapper — while a
+    /// called or subscripted chain's outermost `attribute` node has one of
+    /// those two kinds as its last child instead.
+    fn is_bare_dotted_attribute(node: TsNode<'_>) -> bool {
+        let mut cursor = node.walk();
+        if !cursor.goto_first_child() {
+            return false;
+        }
+        loop {
+            let c = cursor.node();
+            if c.is_named() && matches!(c.kind(), "attribute_call" | "attribute_subscript") {
+                return false;
+            }
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+        true
+    }
+
     /// The callee name of a `call` / `attribute_call` node. `attribute_call`
     /// (`obj.method()`) carries the method name as its `identifier` child
-    /// directly (the receiver is a sibling under the enclosing `attribute`
-    /// node, not part of this node). `call` (`foo()`) carries the callee as
-    /// its first named child ahead of the `arguments` field.
+    /// directly; the receiver is a preceding named sibling under the
+    /// enclosing `attribute` node (`attribute(receiver, attribute_call(...))`
+    /// — confirmed via a parse-tree dump), fetched here via
+    /// `prev_named_sibling()` and prefixed on, matching the `receiver.method`
+    /// convention the Python/TS/JS extractors already use for the same
+    /// shape. Previously only the bare method name was emitted, silently
+    /// discarding the receiver — a preload-alias (`XScript.some_method()`) or
+    /// direct class_name receiver (`EquipmentDatabase.get_equipment()`) gave
+    /// the resolver no qualifier to disambiguate a same-named method
+    /// elsewhere. `call` (`foo()`) carries the callee as its first named
+    /// child ahead of the `arguments` field.
     fn callee_name(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         match node.kind() {
             "attribute_call" => {
-                Self::find_child_by_kind(node, "identifier").map(|n| state.node_text(n))
+                let method = Self::find_child_by_kind(node, "identifier")
+                    .map(|n| state.node_text(n))?;
+                if let Some(receiver) = node.prev_named_sibling() {
+                    let receiver_text = state.node_text(receiver);
+                    if !receiver_text.is_empty() {
+                        return Some(format!("{receiver_text}.{method}"));
+                    }
+                }
+                Some(method)
             }
             "call" => {
                 let mut cursor = node.walk();

--- a/tests/gdscript_extraction_test.rs
+++ b/tests/gdscript_extraction_test.rs
@@ -175,8 +175,20 @@ fn call_sites_recorded() {
             .iter()
             .any(|u| u.reference_kind == EdgeKind::Calls && u.reference_name == name)
     };
-    assert!(has_call("take_damage"), "expected call to take_damage");
-    assert!(has_call("append"), "expected attribute_call to append");
+    assert!(has_call("take_damage"), "expected bare call to take_damage");
+    // `items.append(item)` -- an attribute_call now carries its receiver
+    // (`items.append`, not bare `append`) so the resolver can disambiguate a
+    // same-named method on an unrelated class; matches the `receiver.method`
+    // convention the Python/TS/JS extractors already use.
+    assert!(
+        has_call("items.append"),
+        "expected receiver-qualified attribute_call items.append, got: {:?}",
+        r.unresolved_refs
+            .iter()
+            .filter(|u| u.reference_kind == EdgeKind::Calls)
+            .map(|u| u.reference_name.as_str())
+            .collect::<Vec<_>>()
+    );
 }
 
 #[test]
@@ -247,4 +259,273 @@ fn empty_source() {
         .filter(|n| n.kind == NodeKind::File)
         .collect();
     assert_eq!(files.len(), 1);
+}
+
+#[test]
+fn attribute_call_receiver_preserved_for_preload_alias() {
+    // `XScript.some_method()` where XScript is a `const X = preload(...)`
+    // alias (or a direct class_name receiver) — the receiver must be
+    // preserved so a future resolver strategy can disambiguate against a
+    // same-named method elsewhere, instead of the receiver being silently
+    // discarded (the pre-fix behavior).
+    let source = r#"
+class_name Foo
+
+const XScript = preload("res://bar.gd")
+
+func run():
+    XScript.some_method(1, 2)
+"#;
+    let extractor = GdScriptExtractor;
+    let result = extractor.extract("foo.gd", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    assert!(
+        result
+            .unresolved_refs
+            .iter()
+            .any(|u| u.reference_kind == EdgeKind::Calls && u.reference_name == "XScript.some_method"),
+        "expected receiver-qualified XScript.some_method, got: {:?}",
+        result
+            .unresolved_refs
+            .iter()
+            .filter(|u| u.reference_kind == EdgeKind::Calls)
+            .map(|u| u.reference_name.as_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn callable_string_dispatch_target_captured() {
+    // `Callable(receiver, "method_name")` — Godot's string-keyed
+    // deferred-dispatch idiom (`.connect()`, `call_deferred`, dispatch
+    // tables). The string argument names a real method that would otherwise
+    // show zero incoming edges and misreport as dead code.
+    let source = r#"
+class_name Foo
+
+func _ready():
+    var cb = Callable(self, "_on_button_pressed")
+    other.connect("pressed", Callable(self, "_on_button_pressed"))
+
+func _on_button_pressed():
+    pass
+"#;
+    let extractor = GdScriptExtractor;
+    let result = extractor.extract("foo.gd", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let hits = result
+        .unresolved_refs
+        .iter()
+        .filter(|u| u.reference_kind == EdgeKind::Calls && u.reference_name == "_on_button_pressed")
+        .count();
+    assert_eq!(
+        hits, 2,
+        "expected 2 Callable(...) string-target refs to _on_button_pressed, got: {:?}",
+        result
+            .unresolved_refs
+            .iter()
+            .filter(|u| u.reference_kind == EdgeKind::Calls)
+            .map(|u| u.reference_name.as_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn callable_non_callable_call_not_misread() {
+    // A 2-argument call to something that is NOT literally named `Callable`
+    // must not be mistaken for the dispatch idiom (e.g. a normal function
+    // that happens to take a string second argument).
+    let source = r#"
+class_name Foo
+
+func run():
+    some_other_function(self, "not_a_method_ref")
+"#;
+    let extractor = GdScriptExtractor;
+    let result = extractor.extract("foo.gd", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    assert!(
+        !result
+            .unresolved_refs
+            .iter()
+            .any(|u| u.reference_kind == EdgeKind::Calls && u.reference_name == "not_a_method_ref"),
+        "must not treat a non-Callable call's string arg as a dispatch target: {:?}",
+        result.unresolved_refs
+    );
+}
+
+#[test]
+fn bare_dotted_attribute_call_argument_captured() {
+    // `get_or_create(_h, MyDb._load_from_registry)` — a function reference
+    // passed BY VALUE (no call parens), the lazy-init/dispatch-table idiom
+    // this codebase's BaseDatabaseCache pattern relies on. Previously
+    // invisible to the extractor entirely (no call/attribute_call node at
+    // that position), so the referenced function showed zero incoming edges.
+    let source = r#"
+class_name Foo
+
+static var _h
+
+static func _load_from_registry():
+    pass
+
+static func get_or_create(h, loader):
+    pass
+
+func run():
+    get_or_create(_h, Foo._load_from_registry)
+"#;
+    let extractor = GdScriptExtractor;
+    let result = extractor.extract("foo.gd", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    assert!(
+        result
+            .unresolved_refs
+            .iter()
+            .any(|u| u.reference_kind == EdgeKind::Calls && u.reference_name == "Foo._load_from_registry"),
+        "expected a bare dotted-attribute call-argument ref to Foo._load_from_registry, got: {:?}",
+        result
+            .unresolved_refs
+            .iter()
+            .filter(|u| u.reference_kind == EdgeKind::Calls)
+            .map(|u| u.reference_name.as_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn bare_dotted_attribute_call_still_recorded_normally() {
+    // A bare dotted attribute that IS a call (`MyDb.some_method()`) must
+    // still be recorded via the normal attribute_call path, not double
+    // counted or dropped by the new bare-argument scan (which only matches
+    // the non-call, non-subscript leaf shape).
+    let source = r#"
+class_name Foo
+
+func run(a, b):
+    MyDb.some_method(a, b)
+"#;
+    let extractor = GdScriptExtractor;
+    let result = extractor.extract("foo.gd", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let hits: Vec<_> = result
+        .unresolved_refs
+        .iter()
+        .filter(|u| u.reference_kind == EdgeKind::Calls)
+        .map(|u| u.reference_name.as_str())
+        .collect();
+    assert_eq!(
+        hits,
+        vec!["MyDb.some_method"],
+        "expected exactly one receiver-qualified call ref, not a duplicate or a dropped one: {hits:?}"
+    );
+}
+
+#[test]
+fn call_deferred_string_target_captured() {
+    // `call_deferred("method_name")` (bare or receiver-qualified) -- Godot's
+    // deferred-call API, string-named. Same invisibility problem as
+    // Callable(...): the target only shows up as a string, not a real edge.
+    let source = r#"
+class_name Foo
+
+func _ready():
+    call_deferred("_late_init")
+    other.call_deferred("_late_init")
+
+func _late_init():
+    pass
+"#;
+    let extractor = GdScriptExtractor;
+    let result = extractor.extract("foo.gd", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let hits = result
+        .unresolved_refs
+        .iter()
+        .filter(|u| u.reference_kind == EdgeKind::Calls && u.reference_name == "_late_init")
+        .count();
+    assert_eq!(
+        hits, 2,
+        "expected 2 call_deferred(...) string-target refs to _late_init, got: {:?}",
+        result
+            .unresolved_refs
+            .iter()
+            .filter(|u| u.reference_kind == EdgeKind::Calls)
+            .map(|u| u.reference_name.as_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn connect_bare_callback_reference_captured() {
+    // `signal.connect(callback)` -- Godot's signal-connect API, `callback` a
+    // bare identifier or bare dotted-attribute function reference (no call
+    // parens). This is the single most common false-negative source found in
+    // this codebase's own dead-code audits.
+    let source = r#"
+class_name Foo
+
+func _ready():
+    pressed.connect(_on_pressed)
+    other_signal.connect(Foo._static_handler)
+
+func _on_pressed():
+    pass
+
+static func _static_handler():
+    pass
+"#;
+    let extractor = GdScriptExtractor;
+    let result = extractor.extract("foo.gd", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let calls: Vec<_> = result
+        .unresolved_refs
+        .iter()
+        .filter(|u| u.reference_kind == EdgeKind::Calls)
+        .map(|u| u.reference_name.as_str())
+        .collect();
+    assert!(
+        calls.contains(&"_on_pressed"),
+        "expected bare identifier connect target _on_pressed, got: {calls:?}"
+    );
+    assert!(
+        calls.contains(&"Foo._static_handler"),
+        "expected dotted connect target Foo._static_handler, got: {calls:?}"
+    );
+}
+
+#[test]
+fn connect_with_call_argument_not_double_counted() {
+    // `signal.connect(some_call())` -- the argument IS itself a call, not a
+    // bare reference. Must not be misread as a bare-identifier/attribute
+    // connect target (it already gets its own normal Calls edge via the
+    // inner call itself).
+    let source = r#"
+class_name Foo
+
+func _ready():
+    pressed.connect(make_callback())
+
+func make_callback() -> Callable:
+    return Callable()
+"#;
+    let extractor = GdScriptExtractor;
+    let result = extractor.extract("foo.gd", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let calls: Vec<_> = result
+        .unresolved_refs
+        .iter()
+        .filter(|u| u.reference_kind == EdgeKind::Calls)
+        .map(|u| u.reference_name.as_str())
+        .collect();
+    assert!(
+        calls.contains(&"make_callback"),
+        "expected the inner call itself recorded: {calls:?}"
+    );
+    // The connect call itself is also recorded, receiver-qualified per the
+    // attribute_call receiver fix.
+    assert!(
+        calls.contains(&"pressed.connect"),
+        "expected connect itself recorded (receiver-qualified): {calls:?}"
+    );
 }

--- a/tests/gdscript_extraction_test.rs
+++ b/tests/gdscript_extraction_test.rs
@@ -283,7 +283,8 @@ func run():
         result
             .unresolved_refs
             .iter()
-            .any(|u| u.reference_kind == EdgeKind::Calls && u.reference_name == "XScript.some_method"),
+            .any(|u| u.reference_kind == EdgeKind::Calls
+                && u.reference_name == "XScript.some_method"),
         "expected receiver-qualified XScript.some_method, got: {:?}",
         result
             .unresolved_refs
@@ -319,7 +320,8 @@ func _on_button_pressed():
         .filter(|u| u.reference_kind == EdgeKind::Calls && u.reference_name == "_on_button_pressed")
         .count();
     assert_eq!(
-        hits, 2,
+        hits,
+        2,
         "expected 2 Callable(...) string-target refs to _on_button_pressed, got: {:?}",
         result
             .unresolved_refs
@@ -382,7 +384,8 @@ func run():
         result
             .unresolved_refs
             .iter()
-            .any(|u| u.reference_kind == EdgeKind::Calls && u.reference_name == "Foo._load_from_registry"),
+            .any(|u| u.reference_kind == EdgeKind::Calls
+                && u.reference_name == "Foo._load_from_registry"),
         "expected a bare dotted-attribute call-argument ref to Foo._load_from_registry, got: {:?}",
         result
             .unresolved_refs
@@ -445,7 +448,8 @@ func _late_init():
         .filter(|u| u.reference_kind == EdgeKind::Calls && u.reference_name == "_late_init")
         .count();
     assert_eq!(
-        hits, 2,
+        hits,
+        2,
         "expected 2 call_deferred(...) string-target refs to _late_init, got: {:?}",
         result
             .unresolved_refs


### PR DESCRIPTION
Prompted by a downstream project's dead-code audit: 4 parallel triage
passes checked 482 raw `tokensave_dead_code` candidates by hand and found
~86% were false positives from extraction gaps in this file, not real
dead code. Fixed 3 concrete gaps, each verified via a parse-tree dump
against the live grammar (not inferred from node-types.json alone, which
under-documents the bare-attribute shape) and a before/after
`tokensave_callers` check against real examples in that downstream repo:

1. `attribute_call`'s `callee_name()` only emitted the bare method name
   (`some_method`), discarding the receiver entirely -- `XScript.
   some_method()` and `some_method()` were indistinguishable to the
   resolver. Now emits `receiver.method`, matching the convention the
   Python/TS/JS extractors already use for the same shape.

2. A function reference passed BY VALUE with no call parens
   (`get_or_create(_h, MyDb._load_from_registry)`, the BaseDatabaseCache
   lazy-init idiom) produced zero extraction output at all -- it's
   neither a `call` nor `attribute_call` node. Added a scan of each
   call's `arguments` node for bare dotted-attribute children (identifier
   pairs with no trailing attribute_call/attribute_subscript), recorded
   as Calls-kind references.

3. Three well-known Godot dynamic-dispatch APIs -- `Callable(receiver,
   "method_name")`, `X.call_deferred("method_name")`, `X.connect(callback)`
   (bare identifier or bare dotted-attribute callback) -- previously
   contributed nothing beyond the ordinary call-to-themselves edge. Added
   narrow, name-matched extraction of the string/bare-reference target
   for each.

## Not fixed by this change
Both need a receiver-type-aware resolver strategy (tracking what a
preload const or local variable is actually an instance of), not just an
extraction-side text-preservation fix:
- Ambiguous resolution when 2+ files define a same-named function: the
  new receiver-qualified text is emitted correctly, but `resolve_one`'s
  bare-name matching can still attribute a reference to the wrong
  same-named candidate.
- `const X = preload("res://...")` alias indirection (`X.some_method()`)
  -- the receiver text is now preserved, but nothing maps the alias name
  back to the file it points at.
- `.has_method("x")`-guarded duck-typed dispatch, and typed-local-variable
  dispatch (`var ctrl: SomeController; ctrl.some_method()`) where the
  variable's declared type would need tracking through the function body.

## Test plan
- Full test suite (90 test binaries, unit + integration + doc tests)
  passes with zero regressions.
- Rebuilt release binary, ran a fresh full sync against a real
  ~500-file GDScript project (62481 -> 74770 edges), confirmed 3
  concrete previously-false-positive examples now show correct callers.


---
**Update:** pushed a follow-up commit (`fix(gdscript): satisfy CI clippy::pedantic and rustfmt`) — doc-comment formatting only (blank lines before trailing paragraphs, backticked two bare identifiers), no logic change. CI is green.

