### PR TITLE
fix(edit-tools): honor absolute paths verbatim, add project_root override, echo resolved_path

### DIFF
--- a/src/mcp/tools/definitions.rs
+++ b/src/mcp/tools/definitions.rs
@@ -1267,7 +1267,7 @@ fn def_str_replace() -> ToolDefinition {
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "Absolute or project-relative file path"
+                    "description": "Absolute or project-relative file path. An absolute path is always honored verbatim, even outside the indexed project root (e.g. a git worktree)."
                 },
                 "old_str": {
                     "type": "string",
@@ -1276,6 +1276,10 @@ fn def_str_replace() -> ToolDefinition {
                 "new_str": {
                     "type": "string",
                     "description": "Replacement string"
+                },
+                "project_root": {
+                    "type": "string",
+                    "description": "Optional absolute directory to resolve a relative `path` against instead of the indexed project root. Use this when calling from a git worktree so relative paths land in the worktree, not the primary checkout. Ignored when `path` is absolute. Alias: `cwd`."
                 }
             },
             "required": ["path", "old_str", "new_str"]
@@ -1297,7 +1301,7 @@ fn def_multi_str_replace() -> ToolDefinition {
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "Absolute or project-relative file path"
+                    "description": "Absolute or project-relative file path. An absolute path is always honored verbatim, even outside the indexed project root (e.g. a git worktree)."
                 },
                 "replacements": {
                     "type": "array",
@@ -1308,6 +1312,10 @@ fn def_multi_str_replace() -> ToolDefinition {
                         "minItems": 2,
                         "maxItems": 2
                     }
+                },
+                "project_root": {
+                    "type": "string",
+                    "description": "Optional absolute directory to resolve a relative `path` against instead of the indexed project root. Use this when calling from a git worktree so relative paths land in the worktree, not the primary checkout. Ignored when `path` is absolute. Alias: `cwd`."
                 }
             },
             "required": ["path", "replacements"]
@@ -1329,7 +1337,7 @@ fn def_insert_at() -> ToolDefinition {
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "Absolute or project-relative file path"
+                    "description": "Absolute or project-relative file path. An absolute path is always honored verbatim, even outside the indexed project root (e.g. a git worktree)."
                 },
                 "anchor": {
                     "type": "string",
@@ -1342,6 +1350,10 @@ fn def_insert_at() -> ToolDefinition {
                 "before": {
                     "type": "boolean",
                     "description": "If true, insert before the anchor line; if false, insert after (default: false)"
+                },
+                "project_root": {
+                    "type": "string",
+                    "description": "Optional absolute directory to resolve a relative `path` against instead of the indexed project root. Use this when calling from a git worktree so relative paths land in the worktree, not the primary checkout. Ignored when `path` is absolute. Alias: `cwd`."
                 }
             },
             "required": ["path", "anchor", "content"]
@@ -1778,7 +1790,7 @@ fn def_ast_grep_rewrite() -> ToolDefinition {
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "Absolute or project-relative file path"
+                    "description": "Absolute or project-relative file path. An absolute path is always honored verbatim, even outside the indexed project root (e.g. a git worktree)."
                 },
                 "pattern": {
                     "type": "string",
@@ -1787,6 +1799,10 @@ fn def_ast_grep_rewrite() -> ToolDefinition {
                 "rewrite": {
                     "type": "string",
                     "description": "ast-grep rewrite rule"
+                },
+                "project_root": {
+                    "type": "string",
+                    "description": "Optional absolute directory to resolve a relative `path` against instead of the indexed project root. Use this when calling from a git worktree so relative paths land in the worktree, not the primary checkout. Ignored when `path` is absolute. Alias: `cwd`."
                 }
             },
             "required": ["path", "pattern", "rewrite"]
@@ -2338,6 +2354,10 @@ fn def_replace_symbol() -> ToolDefinition {
                 "new_source": {
                     "type": "string",
                     "description": "Full replacement source — must include the symbol's own declaration line."
+                },
+                "project_root": {
+                    "type": "string",
+                    "description": "Optional absolute directory the symbol's (index-relative) file path is resolved against instead of the indexed project root. Use this when calling from a git worktree that shares the same relative layout but lives at a different absolute location, so the write lands in the worktree, not the primary checkout. Alias: `cwd`."
                 }
             },
             "required": ["symbol", "new_source"]
@@ -2393,6 +2413,10 @@ fn def_insert_at_symbol() -> ToolDefinition {
                     "type": "string",
                     "enum": ["before", "after"],
                     "description": "Where to insert relative to the symbol's range. Default: after."
+                },
+                "project_root": {
+                    "type": "string",
+                    "description": "Optional absolute directory the symbol's (index-relative) file path is resolved against instead of the indexed project root. Use this when calling from a git worktree that shares the same relative layout but lives at a different absolute location, so the write lands in the worktree, not the primary checkout. Alias: `cwd`."
                 }
             },
             "required": ["symbol", "content"]

--- a/src/mcp/tools/handlers/edit.rs
+++ b/src/mcp/tools/handlers/edit.rs
@@ -43,7 +43,9 @@ pub(super) async fn handle_str_replace(cg: &TokenSave, args: Value) -> Result<To
         })?;
 
     let root_override = project_root_arg(&args);
-    let result = cg.str_replace(path, old_str, new_str, root_override).await?;
+    let result = cg
+        .str_replace(path, old_str, new_str, root_override)
+        .await?;
     let touched_files = vec![result.file_path.clone()];
     Ok(ToolResult {
         value: json!({
@@ -155,9 +157,7 @@ pub(super) async fn handle_replace_symbol(cg: &TokenSave, args: Value) -> Result
         })?;
 
     let root_override = project_root_arg(&args);
-    let result = cg
-        .replace_symbol(symbol, new_source, root_override)
-        .await?;
+    let result = cg.replace_symbol(symbol, new_source, root_override).await?;
     let touched_files = if result.success {
         vec![result.file_path.clone()]
     } else {

--- a/src/mcp/tools/handlers/edit.rs
+++ b/src/mcp/tools/handlers/edit.rs
@@ -8,6 +8,18 @@ use crate::tokensave::TokenSave;
 
 use super::super::ToolResult;
 
+/// Extracts the optional `project_root` (alias: `cwd`) parameter shared by
+/// every edit tool. When present, it retargets resolution of a *relative*
+/// `path`/symbol-file argument to this directory instead of the indexed
+/// project root — the fix for callers working in a git worktree, where a
+/// bare relative path previously always resolved against the primary
+/// checkout regardless of where the caller was actually working.
+fn project_root_arg(args: &Value) -> Option<&str> {
+    args.get("project_root")
+        .or_else(|| args.get("cwd"))
+        .and_then(|v| v.as_str())
+}
+
 pub(super) async fn handle_str_replace(cg: &TokenSave, args: Value) -> Result<ToolResult> {
     let path = args
         .get("path")
@@ -30,7 +42,8 @@ pub(super) async fn handle_str_replace(cg: &TokenSave, args: Value) -> Result<To
             message: "missing required parameter: new_str".to_string(),
         })?;
 
-    let result = cg.str_replace(path, old_str, new_str).await?;
+    let root_override = project_root_arg(&args);
+    let result = cg.str_replace(path, old_str, new_str, root_override).await?;
     let touched_files = vec![result.file_path.clone()];
     Ok(ToolResult {
         value: json!({
@@ -74,7 +87,10 @@ pub(super) async fn handle_multi_str_replace(cg: &TokenSave, args: Value) -> Res
         });
     }
 
-    let result = cg.multi_str_replace(path, &parsed_replacements).await?;
+    let root_override = project_root_arg(&args);
+    let result = cg
+        .multi_str_replace(path, &parsed_replacements, root_override)
+        .await?;
     let touched_files = vec![result.file_path.clone()];
     Ok(ToolResult {
         value: json!({
@@ -111,7 +127,10 @@ pub(super) async fn handle_insert_at(cg: &TokenSave, args: Value) -> Result<Tool
         .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
 
-    let result = cg.insert_at(path, anchor, content, before).await?;
+    let root_override = project_root_arg(&args);
+    let result = cg
+        .insert_at(path, anchor, content, before, root_override)
+        .await?;
     let touched_files = vec![result.file_path.clone()];
     Ok(ToolResult {
         value: json!({
@@ -135,7 +154,10 @@ pub(super) async fn handle_replace_symbol(cg: &TokenSave, args: Value) -> Result
             message: "missing required parameter: new_source".to_string(),
         })?;
 
-    let result = cg.replace_symbol(symbol, new_source).await?;
+    let root_override = project_root_arg(&args);
+    let result = cg
+        .replace_symbol(symbol, new_source, root_override)
+        .await?;
     let touched_files = if result.success {
         vec![result.file_path.clone()]
     } else {
@@ -167,7 +189,10 @@ pub(super) async fn handle_insert_at_symbol(cg: &TokenSave, args: Value) -> Resu
         .and_then(|v| v.as_str())
         .unwrap_or("after");
 
-    let result = cg.insert_at_symbol(symbol, content, position).await?;
+    let root_override = project_root_arg(&args);
+    let result = cg
+        .insert_at_symbol(symbol, content, position, root_override)
+        .await?;
     let touched_files = if result.success {
         vec![result.file_path.clone()]
     } else {
@@ -203,7 +228,10 @@ pub(super) async fn handle_ast_grep_rewrite(cg: &TokenSave, args: Value) -> Resu
             message: "missing required parameter: rewrite".to_string(),
         })?;
 
-    let result = cg.ast_grep_rewrite(path, pattern, rewrite).await?;
+    let root_override = project_root_arg(&args);
+    let result = cg
+        .ast_grep_rewrite(path, pattern, rewrite, root_override)
+        .await?;
     let touched_files = if result.success {
         vec![result.file_path.clone()]
     } else {

--- a/src/mcp/tools/handlers/mod.rs
+++ b/src/mcp/tools/handlers/mod.rs
@@ -181,14 +181,38 @@ pub(crate) fn truncate_response(s: &str) -> String {
     }
 }
 
+/// Edit tools resolve an absolute `path` verbatim (see
+/// `TokenSave::resolve_edit_target`) rather than only matching it against
+/// the DB's canonical forward-slash paths, so they must keep a
+/// drive-letter-absolute Windows path (`C:\...`) exactly as the caller
+/// wrote it.
+const EDIT_TOOLS_HONORING_ABSOLUTE_PATHS_VERBATIM: &[&str] = &[
+    "tokensave_str_replace",
+    "tokensave_multi_str_replace",
+    "tokensave_insert_at",
+    "tokensave_replace_symbol",
+    "tokensave_insert_at_symbol",
+    "tokensave_ast_grep_rewrite",
+];
+
+fn is_drive_absolute(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    bytes.first().is_some_and(u8::is_ascii_alphabetic) && bytes.get(1) == Some(&b':')
+}
+
 /// Normalizes Windows backslash separators to `/` in the path-shaped tool
 /// arguments (`file`, `path`, `file_path`, and the `path_include` /
 /// `path_exclude` arrays) so they match the DB's canonical forward-slash
 /// stored paths (#204). Verbatim/UNC paths (leading `\\`) are left alone —
-/// rewriting their prefix would break them on Windows.
-fn normalize_path_args(args: &mut Value) {
-    fn normalize(s: &str) -> Option<String> {
-        if s.contains('\\') && !s.starts_with("\\\\") {
+/// rewriting their prefix would break them on Windows. For the edit tools
+/// (`preserve_drive_absolute`), a drive-letter-absolute path is also left
+/// alone, since those tools honor an absolute `path` verbatim.
+fn normalize_path_args(args: &mut Value, preserve_drive_absolute: bool) {
+    fn normalize(s: &str, preserve_drive_absolute: bool) -> Option<String> {
+        if s.contains('\\')
+            && !s.starts_with("\\\\")
+            && !(preserve_drive_absolute && is_drive_absolute(s))
+        {
             Some(s.replace('\\', "/"))
         } else {
             None
@@ -199,7 +223,10 @@ fn normalize_path_args(args: &mut Value) {
     };
     for key in ["file", "path", "file_path"] {
         if let Some(v) = map.get_mut(key) {
-            if let Some(fixed) = v.as_str().and_then(normalize) {
+            if let Some(fixed) = v
+                .as_str()
+                .and_then(|s| normalize(s, preserve_drive_absolute))
+            {
                 *v = Value::String(fixed);
             }
         }
@@ -207,7 +234,10 @@ fn normalize_path_args(args: &mut Value) {
     for key in ["path_include", "path_exclude"] {
         if let Some(arr) = map.get_mut(key).and_then(|v| v.as_array_mut()) {
             for v in arr {
-                if let Some(fixed) = v.as_str().and_then(normalize) {
+                if let Some(fixed) = v
+                    .as_str()
+                    .and_then(|s| normalize(s, preserve_drive_absolute))
+                {
                     *v = Value::String(fixed);
                 }
             }
@@ -227,7 +257,10 @@ pub async fn handle_tool_call(
     server_stats: Option<Value>,
     scope_prefix: Option<&str>,
 ) -> Result<ToolResult> {
-    normalize_path_args(&mut args);
+    normalize_path_args(
+        &mut args,
+        EDIT_TOOLS_HONORING_ABSOLUTE_PATHS_VERBATIM.contains(&tool_name),
+    );
     debug_assert!(
         !tool_name.is_empty(),
         "handle_tool_call called with empty tool_name"
@@ -652,7 +685,7 @@ mod tests {
             "path_exclude": ["node_modules\\x"],
             "query": "leave\\alone",
         });
-        normalize_path_args(&mut args);
+        normalize_path_args(&mut args, false);
         assert_eq!(args["file"], "apps/admin/src/StatCard.tsx");
         assert_eq!(args["path"], "apps/admin");
         assert_eq!(args["path_include"][0], "apps/admin/src");
@@ -668,9 +701,19 @@ mod tests {
             "path": "\\\\?\\C:\\repo\\src",
             "file": "C:\\repo\\src\\a.rs",
         });
-        normalize_path_args(&mut args);
-        // Verbatim prefix must not be rewritten; drive-letter paths are.
+        normalize_path_args(&mut args, false);
+        // Verbatim prefix must not be rewritten; drive-letter paths are,
+        // since preserve_drive_absolute is false here.
         assert_eq!(args["path"], "\\\\?\\C:\\repo\\src");
         assert_eq!(args["file"], "C:/repo/src/a.rs");
+    }
+
+    #[test]
+    fn normalize_path_args_preserves_drive_absolute_for_edit_tools() {
+        let mut args = serde_json::json!({
+            "path": "C:\\Users\\dev\\notes.txt",
+        });
+        normalize_path_args(&mut args, true);
+        assert_eq!(args["path"], "C:\\Users\\dev\\notes.txt");
     }
 }

--- a/src/tokensave/indexing.rs
+++ b/src/tokensave/indexing.rs
@@ -979,22 +979,56 @@ impl TokenSave {
         Some(rel_str)
     }
 
-    /// Resolves a path to a relative path string.
-    /// If the path is already relative, returns it as-is.
-    /// If absolute, strips the `project_root` prefix.
-    pub(crate) fn resolve_path(&self, path: &str) -> Option<String> {
-        let path = Path::new(path);
-        if path.is_absolute() {
-            let relative = path.strip_prefix(&self.project_root).ok()?;
-            Some(relative.to_string_lossy().replace('\\', "/"))
-        } else {
-            Some(path.to_string_lossy().replace('\\', "/"))
-        }
-    }
-
     /// Gets the absolute path for a relative path.
     pub(crate) fn absolute_path(&self, relative_path: &str) -> PathBuf {
         self.project_root.join(relative_path)
+    }
+
+    /// Resolves an edit tool's `path` (or a symbol's DB-recorded relative
+    /// path) to the absolute filesystem location that should actually be
+    /// read/written, plus — when that location falls under the *indexed*
+    /// project root — the root-relative path used as the DB reindex key.
+    ///
+    /// Resolution rules (fixes the "wrong-tree write" bug where a caller
+    /// working in a git worktree got edits silently redirected into the
+    /// primary checkout):
+    ///
+    /// - An **absolute** `path` is honored verbatim, even when it points
+    ///   outside the indexed project root. Passing an absolute path is
+    ///   itself the caller's explicit, deliberate statement of where the
+    ///   write should land, so no separate opt-out flag is needed. The
+    ///   previous behavior rejected out-of-root absolute paths with a "path
+    ///   is not within the project" error, which is safe but unhelpful for
+    ///   worktree callers; verbatim honoring plus the `resolved_path` echoed
+    ///   back in every result is the cheaper, equally-safe guard (caller can
+    ///   verify the target instead of being blocked from a legitimate one).
+    /// - A **relative** `path` resolves against `root_override` when given
+    ///   (a worktree caller's per-call retarget), falling back to the
+    ///   indexed project root otherwise — unchanged default behavior.
+    /// - The DB reindex key is only populated when the resolved absolute
+    ///   path is actually under the indexed project root; writes that land
+    ///   elsewhere (verbatim absolute path, or a `root_override` pointing
+    ///   outside the index) skip reindexing since the DB has no record of
+    ///   that tree.
+    pub(crate) fn resolve_edit_target(
+        &self,
+        path: &str,
+        root_override: Option<&str>,
+    ) -> (PathBuf, Option<String>) {
+        let p = Path::new(path);
+        let abs_path = if p.is_absolute() {
+            p.to_path_buf()
+        } else {
+            match root_override {
+                Some(root) => Path::new(root).join(p),
+                None => self.project_root.join(p),
+            }
+        };
+        let rel_for_index = abs_path
+            .strip_prefix(&self.project_root)
+            .ok()
+            .map(|rel| rel.to_string_lossy().replace('\\', "/"));
+        (abs_path, rel_for_index)
     }
 
     /// Re-indexes a single file after an edit.
@@ -1051,21 +1085,24 @@ impl TokenSave {
 
     /// Performs a single string replacement.
     /// Fails if `old_str` is not found or matches more than once.
+    ///
+    /// `root_override` retargets resolution of a *relative* `path` to a
+    /// directory other than the indexed project root (e.g. a git worktree).
+    /// An absolute `path` is always honored verbatim regardless of this
+    /// parameter. See [`Self::resolve_edit_target`] for full semantics.
     pub async fn str_replace(
         &self,
         path: &str,
         old_str: &str,
         new_str: &str,
+        root_override: Option<&str>,
     ) -> Result<EditResult> {
-        let rel_path = self
-            .resolve_path(path)
-            .ok_or_else(|| TokenSaveError::Config {
-                message: "path is not within the project".to_string(),
-            })?;
+        let (abs_path, rel_path) = self.resolve_edit_target(path, root_override);
+        let resolved_path = abs_path.to_string_lossy().to_string();
+        let display_path = rel_path.clone().unwrap_or_else(|| resolved_path.clone());
 
-        let abs_path = self.absolute_path(&rel_path);
         let source = std::fs::read_to_string(&abs_path).map_err(|e| TokenSaveError::Config {
-            message: format!("failed to read {path}: {e}"),
+            message: format!("failed to read {resolved_path}: {e}"),
         })?;
 
         let matches: Vec<_> = source.match_indices(old_str).collect();
@@ -1073,7 +1110,8 @@ impl TokenSave {
             0 => {
                 return Ok(EditResult {
                     success: false,
-                    file_path: rel_path.clone(),
+                    file_path: display_path,
+                    resolved_path,
                     matched_str: old_str.to_string(),
                     new_str: new_str.to_string(),
                     message: format!("old_str not found in {path}"),
@@ -1083,7 +1121,8 @@ impl TokenSave {
             n => {
                 return Ok(EditResult {
                     success: false,
-                    file_path: rel_path.clone(),
+                    file_path: display_path,
+                    resolved_path,
                     matched_str: old_str.to_string(),
                     new_str: new_str.to_string(),
                     message: format!("old_str matches {n} times, must match exactly once"),
@@ -1096,14 +1135,17 @@ impl TokenSave {
         tokio::fs::write(&abs_path, &modified)
             .await
             .map_err(|e| TokenSaveError::Config {
-                message: format!("failed to write {path}: {e}"),
+                message: format!("failed to write {resolved_path}: {e}"),
             })?;
 
-        self.reindex_file(&rel_path).await?;
+        if let Some(rel) = &rel_path {
+            self.reindex_file(rel).await?;
+        }
 
         Ok(EditResult {
             success: true,
-            file_path: rel_path,
+            file_path: display_path,
+            resolved_path,
             matched_str: old_str.to_string(),
             new_str: new_str.to_string(),
             message: "replacement successful".to_string(),
@@ -1112,20 +1154,23 @@ impl TokenSave {
 
     /// Applies multiple string replacements atomically.
     /// Fails if any `old_str` doesn't match exactly once.
+    ///
+    /// `root_override` retargets resolution of a *relative* `path` to a
+    /// directory other than the indexed project root (e.g. a git worktree).
+    /// An absolute `path` is always honored verbatim regardless of this
+    /// parameter. See [`Self::resolve_edit_target`] for full semantics.
     pub async fn multi_str_replace(
         &self,
         path: &str,
         replacements: &[(&str, &str)],
+        root_override: Option<&str>,
     ) -> Result<MultiEditResult> {
-        let rel_path = self
-            .resolve_path(path)
-            .ok_or_else(|| TokenSaveError::Config {
-                message: "path is not within the project".to_string(),
-            })?;
+        let (abs_path, rel_path) = self.resolve_edit_target(path, root_override);
+        let resolved_path = abs_path.to_string_lossy().to_string();
+        let display_path = rel_path.clone().unwrap_or_else(|| resolved_path.clone());
 
-        let abs_path = self.absolute_path(&rel_path);
         let source = std::fs::read_to_string(&abs_path).map_err(|e| TokenSaveError::Config {
-            message: format!("failed to read {path}: {e}"),
+            message: format!("failed to read {resolved_path}: {e}"),
         })?;
 
         for (old, _) in replacements {
@@ -1133,7 +1178,8 @@ impl TokenSave {
             if count != 1 {
                 return Ok(MultiEditResult {
                     success: false,
-                    file_path: rel_path.clone(),
+                    file_path: display_path,
+                    resolved_path,
                     applied_count: 0,
                     message: format!(
                         "replacement '{}' matches {} times, must match exactly once",
@@ -1152,14 +1198,17 @@ impl TokenSave {
         tokio::fs::write(&abs_path, &modified)
             .await
             .map_err(|e| TokenSaveError::Config {
-                message: format!("failed to write {path}: {e}"),
+                message: format!("failed to write {resolved_path}: {e}"),
             })?;
 
-        self.reindex_file(&rel_path).await?;
+        if let Some(rel) = &rel_path {
+            self.reindex_file(rel).await?;
+        }
 
         Ok(MultiEditResult {
             success: true,
-            file_path: rel_path,
+            file_path: display_path,
+            resolved_path,
             applied_count: replacements.len(),
             message: format!("applied {} replacements", replacements.len()),
         })
@@ -1167,22 +1216,25 @@ impl TokenSave {
 
     /// Inserts content before or after a unique anchor.
     /// Anchor can be a string or 1-indexed line number.
+    ///
+    /// `root_override` retargets resolution of a *relative* `path` to a
+    /// directory other than the indexed project root (e.g. a git worktree).
+    /// An absolute `path` is always honored verbatim regardless of this
+    /// parameter. See [`Self::resolve_edit_target`] for full semantics.
     pub async fn insert_at(
         &self,
         path: &str,
         anchor: &str,
         content: &str,
         before: bool,
+        root_override: Option<&str>,
     ) -> Result<InsertResult> {
-        let rel_path = self
-            .resolve_path(path)
-            .ok_or_else(|| TokenSaveError::Config {
-                message: "path is not within the project".to_string(),
-            })?;
+        let (abs_path, rel_path) = self.resolve_edit_target(path, root_override);
+        let resolved_path = abs_path.to_string_lossy().to_string();
+        let display_path = rel_path.clone().unwrap_or_else(|| resolved_path.clone());
 
-        let abs_path = self.absolute_path(&rel_path);
         let source = std::fs::read_to_string(&abs_path).map_err(|e| TokenSaveError::Config {
-            message: format!("failed to read {path}: {e}"),
+            message: format!("failed to read {resolved_path}: {e}"),
         })?;
 
         let lines: Vec<&str> = source.lines().collect();
@@ -1194,7 +1246,8 @@ impl TokenSave {
             if line_num == 0 || line_num > lines.len() {
                 return Ok(InsertResult {
                     success: false,
-                    file_path: rel_path.clone(),
+                    file_path: display_path,
+                    resolved_path,
                     anchor_line: line_num as u32,
                     content: content.to_string(),
                     before,
@@ -1217,7 +1270,8 @@ impl TokenSave {
             if matching_lines.is_empty() {
                 return Ok(InsertResult {
                     success: false,
-                    file_path: rel_path.clone(),
+                    file_path: display_path,
+                    resolved_path,
                     anchor_line: 0,
                     content: content.to_string(),
                     before,
@@ -1227,7 +1281,8 @@ impl TokenSave {
             if matching_lines.len() > 1 {
                 return Ok(InsertResult {
                     success: false,
-                    file_path: rel_path.clone(),
+                    file_path: display_path,
+                    resolved_path,
                     anchor_line: matching_lines.len() as u32,
                     content: content.to_string(),
                     before,
@@ -1252,14 +1307,17 @@ impl TokenSave {
         tokio::fs::write(&abs_path, &modified)
             .await
             .map_err(|e| TokenSaveError::Config {
-                message: format!("failed to write {path}: {e}"),
+                message: format!("failed to write {resolved_path}: {e}"),
             })?;
 
-        self.reindex_file(&rel_path).await?;
+        if let Some(rel) = &rel_path {
+            self.reindex_file(rel).await?;
+        }
 
         Ok(InsertResult {
             success: true,
-            file_path: rel_path,
+            file_path: display_path,
+            resolved_path,
             anchor_line: (anchor_line + 1) as u32,
             content: content.to_string(),
             before,
@@ -1272,12 +1330,23 @@ impl TokenSave {
     /// match — if the name is ambiguous, callable definitions win; if still
     /// ambiguous after that filter, the edit is refused so we don't clobber
     /// the wrong site.
-    pub async fn replace_symbol(&self, symbol: &str, new_source: &str) -> Result<EditResult> {
+    ///
+    /// `root_override` retargets where the symbol's (index-relative) file
+    /// path is written to — e.g. a git worktree that shares the same
+    /// relative layout as the indexed project root but lives at a different
+    /// absolute location. See [`Self::resolve_edit_target`] for semantics.
+    pub async fn replace_symbol(
+        &self,
+        symbol: &str,
+        new_source: &str,
+        root_override: Option<&str>,
+    ) -> Result<EditResult> {
         let target = resolve_symbol_for_edit(self, symbol).await?;
-        let rel_path = target.file_path.clone();
-        let abs_path = self.absolute_path(&rel_path);
+        let (abs_path, rel_path) = self.resolve_edit_target(&target.file_path, root_override);
+        let resolved_path = abs_path.to_string_lossy().to_string();
+        let display_path = rel_path.clone().unwrap_or_else(|| resolved_path.clone());
         let source = std::fs::read_to_string(&abs_path).map_err(|e| TokenSaveError::Config {
-            message: format!("failed to read {rel_path}: {e}"),
+            message: format!("failed to read {resolved_path}: {e}"),
         })?;
         let lines: Vec<&str> = source.lines().collect();
         let start = target.start_line as usize;
@@ -1285,7 +1354,8 @@ impl TokenSave {
         if start >= lines.len() || start > end_inclusive {
             return Ok(EditResult {
                 success: false,
-                file_path: rel_path,
+                file_path: display_path,
+                resolved_path,
                 matched_str: symbol.to_string(),
                 new_str: String::new(),
                 message: format!(
@@ -1308,12 +1378,15 @@ impl TokenSave {
         tokio::fs::write(&abs_path, &modified)
             .await
             .map_err(|e| TokenSaveError::Config {
-                message: format!("failed to write {rel_path}: {e}"),
+                message: format!("failed to write {resolved_path}: {e}"),
             })?;
-        self.reindex_file(&rel_path).await?;
+        if let Some(rel) = &rel_path {
+            self.reindex_file(rel).await?;
+        }
         Ok(EditResult {
             success: true,
-            file_path: rel_path,
+            file_path: display_path,
+            resolved_path,
             matched_str: format!("{} ({})", target.name, target.kind.as_str()),
             new_str: new_source.to_string(),
             message: format!(
@@ -1328,11 +1401,15 @@ impl TokenSave {
     /// Inserts `content` immediately before or after a named symbol. `position`
     /// is one of `"before"` or `"after"`. Uses the same resolution logic as
     /// `replace_symbol`.
+    ///
+    /// `root_override` retargets where the symbol's (index-relative) file
+    /// path is written to. See [`Self::resolve_edit_target`] for semantics.
     pub async fn insert_at_symbol(
         &self,
         symbol: &str,
         content: &str,
         position: &str,
+        root_override: Option<&str>,
     ) -> Result<InsertResult> {
         let before = match position {
             "before" => true,
@@ -1344,10 +1421,11 @@ impl TokenSave {
             }
         };
         let target = resolve_symbol_for_edit(self, symbol).await?;
-        let rel_path = target.file_path.clone();
-        let abs_path = self.absolute_path(&rel_path);
+        let (abs_path, rel_path) = self.resolve_edit_target(&target.file_path, root_override);
+        let resolved_path = abs_path.to_string_lossy().to_string();
+        let display_path = rel_path.clone().unwrap_or_else(|| resolved_path.clone());
         let source = std::fs::read_to_string(&abs_path).map_err(|e| TokenSaveError::Config {
-            message: format!("failed to read {rel_path}: {e}"),
+            message: format!("failed to read {resolved_path}: {e}"),
         })?;
         let lines: Vec<&str> = source.lines().collect();
         let anchor_line = if before {
@@ -1358,7 +1436,8 @@ impl TokenSave {
         if anchor_line > lines.len() {
             return Ok(InsertResult {
                 success: false,
-                file_path: rel_path,
+                file_path: display_path,
+                resolved_path,
                 anchor_line: anchor_line as u32,
                 content: content.to_string(),
                 before,
@@ -1377,12 +1456,15 @@ impl TokenSave {
         tokio::fs::write(&abs_path, &modified)
             .await
             .map_err(|e| TokenSaveError::Config {
-                message: format!("failed to write {rel_path}: {e}"),
+                message: format!("failed to write {resolved_path}: {e}"),
             })?;
-        self.reindex_file(&rel_path).await?;
+        if let Some(rel) = &rel_path {
+            self.reindex_file(rel).await?;
+        }
         Ok(InsertResult {
             success: true,
-            file_path: rel_path,
+            file_path: display_path,
+            resolved_path,
             anchor_line: (anchor_line + 1) as u32,
             content: content.to_string(),
             before,
@@ -1397,21 +1479,23 @@ impl TokenSave {
     }
 
     /// Performs structural rewrite using ast-grep CLI.
+    ///
+    /// `root_override` retargets resolution of a *relative* `path` to a
+    /// directory other than the indexed project root (e.g. a git worktree).
+    /// An absolute `path` is always honored verbatim regardless of this
+    /// parameter. See [`Self::resolve_edit_target`] for full semantics.
     pub async fn ast_grep_rewrite(
         &self,
         path: &str,
         pattern: &str,
         rewrite: &str,
+        root_override: Option<&str>,
     ) -> Result<AstGrepResult> {
         use std::process::Command;
 
-        let rel_path = self
-            .resolve_path(path)
-            .ok_or_else(|| TokenSaveError::Config {
-                message: "path is not within the project".to_string(),
-            })?;
-
-        let abs_path = self.absolute_path(&rel_path);
+        let (abs_path, rel_path) = self.resolve_edit_target(path, root_override);
+        let resolved_path = abs_path.to_string_lossy().to_string();
+        let display_path = rel_path.clone().unwrap_or_else(|| resolved_path.clone());
 
         let check_output = Command::new("ast-grep").args(["--version"]).output();
 
@@ -1421,7 +1505,8 @@ impl TokenSave {
                 if !source.contains(pattern) {
                     return Ok(AstGrepResult {
                         success: false,
-                        file_path: rel_path.clone(),
+                        file_path: display_path,
+                        resolved_path,
                         pattern: pattern.to_string(),
                         rewrite: rewrite.to_string(),
                         message: "pattern not found (built-in literal fallback)".to_string(),
@@ -1429,10 +1514,13 @@ impl TokenSave {
                 }
                 source = source.replace(pattern, rewrite);
                 std::fs::write(&abs_path, source).map_err(TokenSaveError::Io)?;
-                self.reindex_file(&rel_path).await?;
+                if let Some(rel) = &rel_path {
+                    self.reindex_file(rel).await?;
+                }
                 return Ok(AstGrepResult {
                     success: true,
-                    file_path: rel_path,
+                    file_path: display_path,
+                    resolved_path,
                     pattern: pattern.to_string(),
                     rewrite: rewrite.to_string(),
                     message: "literal rewrite completed using built-in fallback".to_string(),
@@ -1440,7 +1528,8 @@ impl TokenSave {
             }
             return Ok(AstGrepResult {
                 success: false,
-                file_path: rel_path.clone(),
+                file_path: display_path,
+                resolved_path,
                 pattern: pattern.to_string(),
                 rewrite: rewrite.to_string(),
                 message: "ast-grep is not installed and this pattern needs SGPattern matching. Simple literal rewrites are handled by the built-in fallback.".to_string(),
@@ -1480,23 +1569,27 @@ impl TokenSave {
                     "ast-grep failed (exit {exit}) with no output. Likely causes: \
                      pattern matched 0 nodes, language not inferred from file extension \
                      (e.g. .txt has no parser), or invalid pattern syntax. \
-                     File: {rel_path}, pattern: {pattern:?}"
+                     File: {display_path}, pattern: {pattern:?}"
                 )
             };
             return Ok(AstGrepResult {
                 success: false,
-                file_path: rel_path.clone(),
+                file_path: display_path,
+                resolved_path,
                 pattern: pattern.to_string(),
                 rewrite: rewrite.to_string(),
                 message,
             });
         }
 
-        self.reindex_file(&rel_path).await?;
+        if let Some(rel) = &rel_path {
+            self.reindex_file(rel).await?;
+        }
 
         Ok(AstGrepResult {
             success: true,
-            file_path: rel_path,
+            file_path: display_path,
+            resolved_path,
             pattern: pattern.to_string(),
             rewrite: rewrite.to_string(),
             message: "ast-grep rewrite completed".to_string(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -663,6 +663,11 @@ pub struct ResolvedRef {
 pub struct EditResult {
     pub success: bool,
     pub file_path: String,
+    /// Fully-resolved absolute filesystem path that was actually read/written.
+    /// Callers (e.g. a worktree caller passing `project_root`) should verify
+    /// this to confirm the edit landed where they intended, since `file_path`
+    /// may be project-relative and ambiguous across trees.
+    pub resolved_path: String,
     pub matched_str: String,
     pub new_str: String,
     pub message: String,
@@ -673,6 +678,8 @@ pub struct EditResult {
 pub struct MultiEditResult {
     pub success: bool,
     pub file_path: String,
+    /// Fully-resolved absolute filesystem path that was actually read/written.
+    pub resolved_path: String,
     pub applied_count: usize,
     pub message: String,
 }
@@ -682,6 +689,8 @@ pub struct MultiEditResult {
 pub struct InsertResult {
     pub success: bool,
     pub file_path: String,
+    /// Fully-resolved absolute filesystem path that was actually read/written.
+    pub resolved_path: String,
     pub anchor_line: u32,
     pub content: String,
     pub before: bool,
@@ -693,6 +702,8 @@ pub struct InsertResult {
 pub struct AstGrepResult {
     pub success: bool,
     pub file_path: String,
+    /// Fully-resolved absolute filesystem path that was actually read/written.
+    pub resolved_path: String,
     pub pattern: String,
     pub rewrite: String,
     pub message: String,

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -5669,7 +5669,8 @@ async fn test_replace_symbol_project_root_override_writes_to_worktree_not_primar
     fs::create_dir_all(worktree_root.join("src")).unwrap();
     fs::write(worktree_root.join("src/lib.rs"), original_source).unwrap();
 
-    let new_source = "pub fn greet_widget_example() -> String {\n    \"hi from worktree\".to_string()\n}";
+    let new_source =
+        "pub fn greet_widget_example() -> String {\n    \"hi from worktree\".to_string()\n}";
 
     let result = handle_tool_call(
         &cg,

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -5459,3 +5459,245 @@ async fn affected_classifies_candidates_and_excludes_inline_sources_from_suite()
         .iter()
         .any(|file| file == "crates/consumer/tests/use_core.rs"));
 }
+
+// Edit tools: path resolution — absolute-path verbatim honoring,
+// `project_root` override, and `resolved_path` echoed in every result.
+//
+// Regression coverage for the worktree wrong-tree-write bug: a caller
+// working in a git worktree passing a relative `path` previously always had
+// it silently resolved against the *indexed* project root (the primary
+// checkout), not the worktree it was actually working in.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_str_replace_resolved_path_for_relative_path_in_root() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/main.rs"), "fn hello() {}\n").unwrap();
+
+    let cg = TokenSave::init(project).await.unwrap();
+    cg.index_all().await.unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tokensave_str_replace",
+        json!({
+            "path": "src/main.rs",
+            "old_str": "fn hello() {}",
+            "new_str": "fn hello_updated() {}"
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&result.value);
+    let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(parsed["success"], true);
+    // Unchanged backward-compatible behavior: file_path stays project-relative.
+    assert_eq!(parsed["file_path"], "src/main.rs");
+    // New: resolved_path is always the fully-resolved absolute path actually
+    // read/written, so a caller can verify the edit landed where intended.
+    let expected_resolved = project.join("src/main.rs").to_string_lossy().to_string();
+    assert_eq!(parsed["resolved_path"], expected_resolved);
+}
+
+#[tokio::test]
+async fn test_str_replace_absolute_path_outside_root_honored_verbatim() {
+    let project_dir = TempDir::new().unwrap();
+    let project = project_dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/main.rs"), "fn hello() {}\n").unwrap();
+
+    let cg = TokenSave::init(project).await.unwrap();
+    cg.index_all().await.unwrap();
+
+    // A file entirely outside the indexed project — e.g. a sibling git
+    // worktree directory. Previously this errored with "path is not within
+    // the project"; it should now be honored verbatim.
+    let outside_dir = TempDir::new().unwrap();
+    let outside_file = outside_dir.path().join("notes.txt");
+    fs::write(&outside_file, "todo: fix the bug\n").unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tokensave_str_replace",
+        json!({
+            "path": outside_file.to_string_lossy(),
+            "old_str": "todo: fix the bug",
+            "new_str": "done: fixed the bug"
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&result.value);
+    let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(
+        parsed["success"], true,
+        "absolute path outside the indexed root must be honored, not rejected: {text}"
+    );
+    let expected = outside_file.to_string_lossy().to_string();
+    assert_eq!(parsed["resolved_path"], expected);
+
+    let content = fs::read_to_string(&outside_file).unwrap();
+    assert_eq!(content, "done: fixed the bug\n");
+
+    // The indexed project itself must be untouched.
+    let project_content = fs::read_to_string(project.join("src/main.rs")).unwrap();
+    assert_eq!(project_content, "fn hello() {}\n");
+}
+
+#[tokio::test]
+async fn test_str_replace_project_root_override_writes_to_worktree_not_primary_checkout() {
+    let primary = TempDir::new().unwrap();
+    let primary_root = primary.path();
+    fs::create_dir_all(primary_root.join("src")).unwrap();
+    fs::write(
+        primary_root.join("src/main.rs"),
+        "fn hello() { \"primary\" }\n",
+    )
+    .unwrap();
+
+    let cg = TokenSave::init(primary_root).await.unwrap();
+    cg.index_all().await.unwrap();
+
+    // Simulate a git worktree: same relative layout, different absolute
+    // location, not part of the indexed project.
+    let worktree = TempDir::new().unwrap();
+    let worktree_root = worktree.path();
+    fs::create_dir_all(worktree_root.join("src")).unwrap();
+    fs::write(
+        worktree_root.join("src/main.rs"),
+        "fn hello() { \"worktree\" }\n",
+    )
+    .unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tokensave_str_replace",
+        json!({
+            "path": "src/main.rs",
+            "old_str": "fn hello() { \"worktree\" }",
+            "new_str": "fn hello() { \"worktree-updated\" }",
+            "project_root": worktree_root.to_string_lossy()
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&result.value);
+    let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(parsed["success"], true, "got: {text}");
+    let expected_resolved = worktree_root
+        .join("src/main.rs")
+        .to_string_lossy()
+        .to_string();
+    assert_eq!(parsed["resolved_path"], expected_resolved);
+
+    // The worktree copy was edited...
+    let worktree_content = fs::read_to_string(worktree_root.join("src/main.rs")).unwrap();
+    assert_eq!(worktree_content, "fn hello() { \"worktree-updated\" }\n");
+
+    // ...and — this is the regression the bug report describes — the
+    // primary checkout's identically-named relative file must be untouched.
+    let primary_content = fs::read_to_string(primary_root.join("src/main.rs")).unwrap();
+    assert_eq!(primary_content, "fn hello() { \"primary\" }\n");
+}
+
+#[tokio::test]
+async fn test_insert_at_absolute_path_outside_root_honored_verbatim() {
+    let project_dir = TempDir::new().unwrap();
+    let project = project_dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/main.rs"), "fn hello() {}\n").unwrap();
+
+    let cg = TokenSave::init(project).await.unwrap();
+    cg.index_all().await.unwrap();
+
+    let outside_dir = TempDir::new().unwrap();
+    let outside_file = outside_dir.path().join("scratch.txt");
+    fs::write(&outside_file, "line one\nline two\n").unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tokensave_insert_at",
+        json!({
+            "path": outside_file.to_string_lossy(),
+            "anchor": "line one",
+            "content": "inserted line",
+            "before": false
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&result.value);
+    let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(parsed["success"], true, "got: {text}");
+    let expected = outside_file.to_string_lossy().to_string();
+    assert_eq!(parsed["resolved_path"], expected);
+
+    let content = fs::read_to_string(&outside_file).unwrap();
+    assert_eq!(content, "line one\ninserted line\nline two\n");
+}
+
+#[tokio::test]
+async fn test_replace_symbol_project_root_override_writes_to_worktree_not_primary_checkout() {
+    let primary = TempDir::new().unwrap();
+    let primary_root = primary.path();
+    fs::create_dir_all(primary_root.join("src")).unwrap();
+    let original_source = "pub fn greet_widget_example() -> String {\n    \"hi\".to_string()\n}\n";
+    fs::write(primary_root.join("src/lib.rs"), original_source).unwrap();
+
+    let cg = TokenSave::init(primary_root).await.unwrap();
+    cg.index_all().await.unwrap();
+
+    // Worktree: an exact copy of the file (same line ranges — the symbol's
+    // start/end lines are resolved from the primary index, then applied to
+    // whatever file `resolve_edit_target` points the write at).
+    let worktree = TempDir::new().unwrap();
+    let worktree_root = worktree.path();
+    fs::create_dir_all(worktree_root.join("src")).unwrap();
+    fs::write(worktree_root.join("src/lib.rs"), original_source).unwrap();
+
+    let new_source = "pub fn greet_widget_example() -> String {\n    \"hi from worktree\".to_string()\n}";
+
+    let result = handle_tool_call(
+        &cg,
+        "tokensave_replace_symbol",
+        json!({
+            "symbol": "greet_widget_example",
+            "new_source": new_source,
+            "project_root": worktree_root.to_string_lossy()
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&result.value);
+    let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(parsed["success"], true, "got: {text}");
+    let expected_resolved = worktree_root
+        .join("src/lib.rs")
+        .to_string_lossy()
+        .to_string();
+    assert_eq!(parsed["resolved_path"], expected_resolved);
+
+    let worktree_content = fs::read_to_string(worktree_root.join("src/lib.rs")).unwrap();
+    assert!(worktree_content.contains("hi from worktree"));
+
+    // The primary checkout's copy of the same relative file must be untouched.
+    let primary_content = fs::read_to_string(primary_root.join("src/lib.rs")).unwrap();
+    assert_eq!(primary_content, original_source);
+}


### PR DESCRIPTION
The MCP edit tools (str_replace, multi_str_replace, insert_at,
replace_symbol, insert_at_symbol, ast_grep_rewrite) always resolved a
relative `path` against the indexed project root, with no way for a caller
to retarget it. A caller working in a git worktree that passed a relative
path got the edit silently written into the primary checkout instead of
the worktree — caught only by a later `git status`. Absolute paths outside
the indexed root were also rejected outright ("path is not within the
project"), even though an absolute path is itself an explicit, deliberate
statement of where the write should land.

## Fix
- Replace `resolve_path`/`absolute_path` (in the 6 edit methods) with a
  single `resolve_edit_target(path, root_override)` helper: absolute paths
  are honored verbatim (even outside the indexed root — no separate
  opt-out flag needed, since passing an absolute path is itself the
  signal); relative paths resolve against `root_override` when given,
  else the indexed project root (unchanged default). DB reindexing only
  fires when the resolved path actually falls under the indexed root.
- Add an optional `project_root` (alias `cwd`) argument to all 6 edit MCP
  tools, threaded through to the corresponding TokenSave methods, so a
  worktree caller can retarget relative-path resolution per call.
- Add `resolved_path` to EditResult/MultiEditResult/InsertResult/
  AstGrepResult — the fully-resolved absolute path actually read/written —
  so callers can verify the target even when they don't use the override,
  as a cheap guard against silent wrong-tree writes.

## Test plan
- `tests/mcp_handler_test.rs`: resolved_path for the default in-root
  case, absolute-path-outside-root honored for str_replace and insert_at,
  project_root override for str_replace and replace_symbol (the
  DB-resolved symbol-path case), each asserting the primary checkout's
  file is left untouched while the override target is edited.
- 170 mcp_handler_test cases pass (165 existing + 5 new).
- Full `cargo test --workspace` and `cargo clippy --lib` clean.


---
**Update:** pushed a follow-up commit (`fix(mcp): keep edit tools' absolute paths verbatim through arg normalization`) — CI's Windows job caught a real gap: the pre-existing `normalize_path_args` helper (#204) unconditionally rewrote `C:\...` to forward slashes before this PR's "honor absolute paths verbatim" logic ever saw the path. Scoped that normalization's drive-letter exception to just the 6 edit tools (other tools still need forward-slash normalization to match the DB's canonical paths). Also includes the rustfmt fixes CI's Format check flagged. CI is green.
