### PR TITLE
fix(pr_context): resolve default branch from branch-meta

### DIFF
--- a/src/mcp/tools/handlers/git.rs
+++ b/src/mcp/tools/handlers/git.rs
@@ -812,10 +812,16 @@ pub(super) async fn handle_commit_context(cg: &TokenSave, args: Value) -> Result
 
 /// Handles `tokensave_pr_context` tool calls.
 pub(super) async fn handle_pr_context(cg: &TokenSave, args: Value) -> Result<ToolResult> {
+    let tokensave_dir = crate::config::get_tokensave_dir(cg.project_root());
+    let meta = crate::branch_meta::load_branch_meta(&tokensave_dir);
+    let default_branch = meta
+        .as_ref()
+        .map(|m| m.default_branch.as_str())
+        .unwrap_or("main");
     let base = args
         .get("base_ref")
         .and_then(|v| v.as_str())
-        .unwrap_or("main");
+        .unwrap_or(default_branch);
     let head = args
         .get("head_ref")
         .and_then(|v| v.as_str())

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -4843,6 +4843,57 @@ async fn pr_context_collapses_cargo_toml_keys() {
     );
 }
 
+/// Regression: `tokensave_pr_context` hardcoded `"main"` as the default
+/// base ref, causing a git error on repos whose default branch is `master`.
+/// The fix reads from `branch-meta.json` when no `base_ref` is provided.
+#[tokio::test]
+async fn pr_context_uses_branch_meta_default_branch() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    fn git(cwd: &std::path::Path, args: &[&str]) {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .unwrap_or_else(|_| panic!("git {args:?} failed"));
+    }
+    git(project, &["init", "-b", "master"]);
+    git(project, &["config", "user.email", "t@t"]);
+    git(project, &["config", "user.name", "t"]);
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+    git(project, &["add", "."]);
+    git(project, &["commit", "-m", "init"]);
+
+    git(project, &["checkout", "-b", "feature"]);
+    fs::write(project.join("src/lib.rs"), "pub fn a() {}\npub fn b() {}\n").unwrap();
+    git(project, &["add", "."]);
+    git(project, &["commit", "-m", "add b"]);
+
+    let cg = TokenSave::init(project).await.unwrap();
+
+    // Write branch-meta with default_branch = "master"
+    let tokensave_dir = tokensave::config::get_tokensave_dir(cg.project_root());
+    let meta = tokensave::branch_meta::BranchMeta::new("master");
+    tokensave::branch_meta::save_branch_meta(&tokensave_dir, &meta).unwrap();
+
+    // Call pr_context WITHOUT base_ref — should resolve to "master", not "main".
+    let result = handle_tool_call(&cg, "tokensave_pr_context", json!({}), None, None)
+        .await
+        .unwrap();
+    let text = extract_text(&result.value);
+    // Must not contain "git error" — that was the symptom of the bug.
+    assert!(
+        !text.contains("git error"),
+        "pr_context should resolve default branch from branch-meta, got: {text}"
+    );
+    let output: Value = serde_json::from_str(text).unwrap();
+    assert!(
+        output.get("added").is_some() || output.get("modified").is_some(),
+        "expected pr_context to return diff data, got: {text}"
+    );
+}
+
 /// Regression for new bug-report batch (#21): `tokensave_unused_imports`
 /// must flag genuinely unused identifiers inside grouped `use foo::{A, B}`
 /// imports. Real-world Rust style is dominated by grouped imports


### PR DESCRIPTION
## Description

resolve default branch from branch-meta instead of hardcoding "main"

`handle_pr_context` hardcoded "main" as the fallback base ref, causing `git error: cannot resolve 'main'` on repos whose default branch is "master" (or any other name). Now reads `default_branch` from `branch-meta.json`, matching what `handle_branch_diff` already does.

## Summary

- `handle_pr_context` now loads `branch-meta.json` and uses `default_branch` as the fallback base ref instead of hardcoding `"main"`
- Falls back to `"main"` only when no branch metadata exists (pre-branch-tracking projects)
- Added regression test `pr_context_uses_branch_meta_default_branch`

## Motivation

Running `tokensave tool pr_context` (or the MCP tool `tokensave_pr_context`) on a repo whose default branch is `master` fails with:

```
git error: cannot resolve 'main': couldn't parse revision: "main"
```

`handle_branch_diff` already resolves the default branch correctly from `branch-meta.json` — `handle_pr_context` should do the same.

## Changes

- `src/mcp/tools/handlers/git.rs` — `handle_pr_context` loads branch metadata and uses `meta.default_branch` as the fallback for `base_ref`
- `tests/mcp_handler_test.rs` — new test creates a repo with `master` as default branch and calls `pr_context` without `base_ref` to verify it resolves correctly

## Test plan

- [x] `cargo test` passes
- [ ] `cargo clippy` has no new warnings
- [x] Tested manually (describe below if applicable)

New regression test `pr_context_uses_branch_meta_default_branch`: creates a git repo with `-b master`, makes a commit, creates a feature branch with a second commit, writes `branch-meta.json` with `default_branch: "master"`, and calls `tokensave_pr_context` with no `base_ref` — asserts no git error and valid diff output.

## Checklist

- [ ] `CHANGELOG.md` updated (under `[Unreleased]` if no version bump)
- [x] No secrets, credentials, or `.env` files included
- [x] Breaking changes documented (if any) — none