### PR TITLE
fix: index source files with invalid UTF-8 bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project uses [maintenance-based versioning](TOKENSAVE-VERSIONING.md), n
 
 ## [Unreleased]
 
+### Fixed
+- **Source files containing invalid UTF-8 bytes are indexed instead of skipped (#241).** Legacy C/C++ sources often contain isolated non-UTF-8 bytes in comments; source reads now replace malformed byte sequences with the Unicode replacement character while preserving the existing UTF-8 and BOM-marked UTF-16 handling.
 
 ## [7.4.0] - 2026-07-16
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -4,8 +4,10 @@ use std::path::Path;
 use sha2::{Digest, Sha256};
 
 /// Read a source file to a UTF-8 string, transparently handling UTF-16 LE/BE
-/// (detected via BOM). Returns an IO error only when the file genuinely cannot
-/// be read or decoded.
+/// (detected via BOM). Invalid non-BOM UTF-8 sequences are replaced with the
+/// Unicode replacement character so legacy-encoded source can still be parsed.
+/// Returns an IO error only when the file cannot be read or BOM-marked UTF-16
+/// cannot be decoded.
 pub fn read_source_file(path: &Path) -> std::io::Result<String> {
     let bytes = std::fs::read(path)?;
 
@@ -35,8 +37,10 @@ pub fn read_source_file(path: &Path) -> std::io::Result<String> {
     } else {
         0
     };
-    String::from_utf8(bytes[start..].to_vec())
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+    match String::from_utf8(bytes[start..].to_vec()) {
+        Ok(source) => Ok(source),
+        Err(error) => Ok(String::from_utf8_lossy(error.as_bytes()).into_owned()),
+    }
 }
 
 /// Get filesystem mtime (seconds since epoch) and size for pre-filter.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -143,6 +143,29 @@ async fn test_incremental_sync() {
 }
 
 #[tokio::test]
+async fn test_indexes_source_with_invalid_utf8_in_comment() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+
+    fs::write(
+        project.join("latin1_repro.c"),
+        b"/* by W\xfcrkner */\nint latin1_symbol(void) { return 42; }\n",
+    )
+    .unwrap();
+
+    let cg = TokenSave::init(project).await.unwrap();
+    cg.index_all().await.unwrap();
+
+    let results = cg.search("latin1_symbol", 10).await.unwrap();
+    assert!(
+        results
+            .iter()
+            .any(|result| result.node.name == "latin1_symbol"),
+        "function in source containing invalid UTF-8 should be indexed"
+    );
+}
+
+#[tokio::test]
 async fn test_init_and_open() {
     let dir = TempDir::new().unwrap();
     let project = dir.path();

--- a/tests/sync_test.rs
+++ b/tests/sync_test.rs
@@ -66,9 +66,13 @@ fn test_read_source_file_utf16_be() {
 }
 
 #[test]
-fn test_read_source_file_invalid_encoding() {
+fn test_read_source_file_replaces_invalid_utf8() {
     let mut f = NamedTempFile::new().unwrap();
-    // Invalid UTF-8 sequence without any BOM
-    f.write_all(b"\x80\x81\x82\x83").unwrap();
-    assert!(read_source_file(f.path()).is_err());
+    f.write_all(b"/* by W\xfcrkner */\nint answer(void) { return 42; }\n")
+        .unwrap();
+    let content = read_source_file(f.path()).unwrap();
+    assert_eq!(
+        content,
+        "/* by W\u{fffd}rkner */\nint answer(void) { return 42; }\n"
+    );
 }


### PR DESCRIPTION
## Summary

- Index source files containing invalid non-BOM UTF-8 instead of skipping them.
- Preserve existing UTF-8, UTF-8 BOM, and BOM-marked UTF-16 handling.

## Motivation

Legacy C and C++ sources commonly contain isolated bytes from encodings such as ISO-8859-1 in comments. Strict UTF-8 decoding caused `tokensave sync` to skip those files entirely.

Closes #241

## Changes

- Fall back to lossy UTF-8 decoding in the shared source-file reader, replacing malformed sequences with U+FFFD.
- Add a unit regression using the issue's `W\xfcrkner` example.
- Add an end-to-end test confirming a C function remains indexed and searchable when its file contains an invalid UTF-8 byte.
- Document the fix under `[Unreleased]` in `CHANGELOG.md`.

## Test plan

- [x] `cargo test` passes
- [x] `cargo clippy` has no new warnings
- [ ] Tested manually (describe below if applicable)

The issue's invalid `0xFC` byte example is covered through the source reader and the full `TokenSave::init` + `index_all` pipeline. The literal CLI reproduction was not run manually.

Additional check: `cargo fmt -- --check` passes.

## Checklist

- [x] `CHANGELOG.md` updated (under `[Unreleased]` if no version bump)
- [x] No secrets, credentials, or `.env` files included
- [x] Breaking changes documented (if any)
