### PR TITLE
feat(droid): extend PreToolUse guardrail to the native Grep tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project uses [maintenance-based versioning](TOKENSAVE-VERSIONING.md), n
 
 ## [Unreleased]
 
+### Added
+- **Factory Droid guardrail hook now also covers the native `Grep` tool (follow-up to the Droid `PreToolUse` hook).** The install matcher widens from `Execute` to `^(Execute|Grep)$` (an anchored regex, verified live to still fire on both tools, so it can never collide with a future tool name that merely contains `Execute`/`Grep`), so a symbol-shaped `pattern` on a code target routed through Droid's own `Grep` tool (previously invisible to the hook) redirects to `tokensave_search`/`tokensave_callers_for`, reaching parity with the Claude hook's Grep coverage. The shared decision core now also reads Droid's `glob_pattern` field alongside Claude's `glob`, and redirects only an explicit `output_mode: "content"`; omitted, malformed, unknown, and cheap path-only modes (including Droid's `file_paths`) pass through. Re-installing over an older `Execute`-only entry migrates it in place instead of adding a duplicate, `doctor` flags stale matchers instead of reporting them healthy, and install/uninstall preserve lookalike custom wrappers by requiring an exact tokensave command. `Read`/`LS`/`Glob`/`Task` are deliberately not matched (lossy or unclassifiable equivalents, and Droid's hard-block contract has no soft-steer channel); see the PR for the full per-tool analysis.
 
 ## [7.4.1] - 2026-07-19
 

--- a/src/agents/droid.rs
+++ b/src/agents/droid.rs
@@ -34,13 +34,25 @@ pub struct DroidIntegration;
 /// before a tool call executes.
 const DROID_PRE_TOOL_EVENT: &str = "PreToolUse";
 
-/// The `Execute` tool is Droid's confirmed shell tool — the only tool name we
-/// register a matcher for. The sub-agent/task launch tool name is
-/// unconfirmed in Factory's public docs, so we
-/// deliberately do not guess a matcher for it: an unmatched tool never
-/// reaches our hook subprocess at all, which is the safest form of
-/// "fail open" for a tool name we can't verify.
-const DROID_HOOK_MATCHER: &str = "Execute";
+/// Regex matcher (Factory treats the value as a regex) covering Droid's two
+/// tool names whose payloads the shared decision core can classify: `Execute`
+/// (shell, a symbol-shaped `grep`/`rg`/`ag` on a code file) and `Grep`
+/// (Droid's native content search, a symbol-shaped `pattern` on a code
+/// target). Both redirect to `tokensave_search`/`tokensave_callers_for`, which
+/// return a compact symbol list instead of raw match lines. The pattern is
+/// anchored (`^(...)$`) so it can only match those exact tool names, never a
+/// future tool whose name merely contains `Execute`/`Grep` as a substring;
+/// anchored matching was verified live to still fire on both tools.
+///
+/// Deliberately excluded (see the PR doc for the full per-tool analysis):
+/// `Read`/`LS`/`Glob` have only lossy tokensave equivalents and no way to
+/// infer symbol intent from a bare path, and Droid's hook contract is a hard
+/// block (exit 2 + stderr) with no confirmed soft-steer channel, so blocking
+/// them would strand legitimate reads. `Task` always carries a typed
+/// `subagent_type` on Droid, so the research classifier (which only fires on
+/// Claude's `Explore` or an untyped research prompt) would never trigger.
+/// Unmatched tools never reach our hook subprocess, the safest "fail open".
+const DROID_HOOK_MATCHER: &str = "^(Execute|Grep)$";
 
 /// Subcommand invoked by the installed hook.
 const DROID_PRE_TOOL_HOOK: &str = "hook-droid-pre-tool-use";
@@ -266,11 +278,31 @@ fn droid_hook_entry_command(entry: &serde_json::Value) -> Option<&str> {
         .find_map(|c| c.get("command").and_then(|v| v.as_str()))
 }
 
+/// Is this `PreToolUse` array entry the tokensave guardrail hook? Matched on
+/// the tokensave binary plus exact `hook-droid-pre-tool-use` subcommand rather
+/// than the matcher value, so an older `"Execute"` install is migrated without
+/// mistaking an unrelated wrapper path for our hook.
+fn is_tokensave_droid_hook(entry: &serde_json::Value) -> bool {
+    let Some(command) = droid_hook_entry_command(entry) else {
+        return false;
+    };
+    let mut parts = command.split_whitespace();
+    let binary_is_tokensave = parts
+        .next()
+        .and_then(|binary| Path::new(binary).file_stem())
+        .and_then(|stem| stem.to_str())
+        .is_some_and(|stem| stem == "tokensave");
+    binary_is_tokensave && parts.next() == Some(DROID_PRE_TOOL_HOOK) && parts.next().is_none()
+}
+
 /// Install the `PreToolUse` guardrail hook into `settings.json`'s `hooks`
-/// object (idempotent), preserving every other key — including hook wrappers
+/// object (idempotent), preserving every other key, including hook wrappers
 /// Factory or other tools already installed (e.g. the owner's own
-/// `PreToolUse` permission wrapper). Adds a new array entry under the
-/// `Execute` matcher rather than touching any existing entry.
+/// `PreToolUse` permission wrapper). Upserts the tokensave entry under the
+/// current `^(Execute|Grep)$` matcher: a tokensave entry already carrying that
+/// matcher is left untouched, while an entry written by an older tokensave
+/// (identified by its `hook-droid-pre-tool-use` subcommand, not its matcher)
+/// is migrated in place, so re-installing never leaves a duplicate.
 fn install_hook(settings_path: &Path, tokensave_bin: &str) -> Result<()> {
     if let Some(parent) = settings_path.parent() {
         std::fs::create_dir_all(parent).ok();
@@ -292,17 +324,26 @@ fn install_hook(settings_path: &Path, tokensave_bin: &str) -> Result<()> {
         .cloned()
         .unwrap_or_default();
 
-    let has_hook = hooks_arr.iter().any(|entry| {
-        entry.get("matcher").and_then(|v| v.as_str()) == Some(DROID_HOOK_MATCHER)
-            && droid_hook_entry_command(entry).is_some_and(|c| c.contains("tokensave"))
+    // Already current: a tokensave entry exists *and* carries the current
+    // matcher — nothing to do. A tokensave entry with a stale matcher (an
+    // older `"Execute"`-only install) is not "current" and falls through to
+    // the rebuild below, which drops it and writes the widened matcher.
+    let already_current = hooks_arr.iter().any(|entry| {
+        is_tokensave_droid_hook(entry)
+            && entry.get("matcher").and_then(|v| v.as_str()) == Some(DROID_HOOK_MATCHER)
     });
-
-    if has_hook {
+    if already_current {
         eprintln!("  {DROID_PRE_TOOL_EVENT} hook already present, skipping");
         return Ok(());
     }
 
-    let mut new_hooks = hooks_arr;
+    // Rebuild: drop any existing tokensave entry (migrating a stale matcher in
+    // place) while preserving every non-tokensave hook, then append the
+    // current one.
+    let mut new_hooks: Vec<serde_json::Value> = hooks_arr
+        .into_iter()
+        .filter(|entry| !is_tokensave_droid_hook(entry))
+        .collect();
     new_hooks.push(json!({
         "matcher": DROID_HOOK_MATCHER,
         "hooks": [{
@@ -445,10 +486,7 @@ fn uninstall_hook(settings_path: &Path) {
     let original_len = arr.len();
     let filtered: Vec<serde_json::Value> = arr
         .into_iter()
-        .filter(|entry| {
-            !(entry.get("matcher").and_then(|v| v.as_str()) == Some(DROID_HOOK_MATCHER)
-                && droid_hook_entry_command(entry).is_some_and(|c| c.contains("tokensave")))
-        })
+        .filter(|entry| !is_tokensave_droid_hook(entry))
         .collect();
 
     if filtered.len() == original_len {
@@ -555,12 +593,7 @@ fn doctor_check_hook(dc: &mut DoctorCounters, home: &Path) {
         .get("hooks")
         .and_then(|v| v.get(DROID_PRE_TOOL_EVENT))
         .and_then(|v| v.as_array())
-        .and_then(|arr| {
-            arr.iter().find(|entry| {
-                entry.get("matcher").and_then(|v| v.as_str()) == Some(DROID_HOOK_MATCHER)
-                    && droid_hook_entry_command(entry).is_some_and(|c| c.contains("tokensave"))
-            })
-        });
+        .and_then(|arr| arr.iter().find(|entry| is_tokensave_droid_hook(entry)));
 
     let Some(hook) = hook else {
         dc.fail(&format!(
@@ -569,6 +602,14 @@ fn doctor_check_hook(dc: &mut DoctorCounters, home: &Path) {
         ));
         return;
     };
+
+    if hook.get("matcher").and_then(|v| v.as_str()) != Some(DROID_HOOK_MATCHER) {
+        dc.fail(&format!(
+            "PreToolUse hook matcher is outdated in {} — run `tokensave install --agent droid`",
+            path.display()
+        ));
+        return;
+    }
 
     dc.pass(&format!("PreToolUse hook installed in {}", path.display()));
 

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -292,15 +292,19 @@ fn evaluate_grep_tool_input(parsed: &Value, env: &HookEnv) -> Option<String> {
     if pattern.is_empty() || pattern.len() > MAX_PATTERN_LEN {
         return None;
     }
-    let output_mode = parsed
-        .get("output_mode")
-        .and_then(|v| v.as_str())
-        .unwrap_or("content");
-    if matches!(output_mode, "files_with_matches" | "count") {
+    // Both harnesses default an omitted mode to a cheap path-only result.
+    // Redirect only explicit content searches; missing, malformed, cheap, or
+    // unknown modes fail open.
+    if parsed.get("output_mode").and_then(|v| v.as_str()) != Some("content") {
         return None;
     }
     let path = parsed.get("path").and_then(|v| v.as_str()).unwrap_or("");
-    let glob = parsed.get("glob").and_then(|v| v.as_str()).unwrap_or("");
+    // Claude names this field `glob`; Droid names it `glob_pattern`.
+    let glob = parsed
+        .get("glob")
+        .or_else(|| parsed.get("glob_pattern"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
     let ty = parsed.get("type").and_then(|v| v.as_str()).unwrap_or("");
     if !target_looks_like_code(path, glob, ty) {
         return None;
@@ -613,12 +617,13 @@ fn is_kiro_delegation_tool(tool_name: &str) -> bool {
 /// Droid delivers the hook event as JSON on stdin with the tool payload
 /// nested under `tool_input` — the same envelope shape Claude Code uses —
 /// but blocks a tool call via **exit code 2 + stderr**, the same mechanism
-/// Kiro uses (not Claude's stdout JSON decision). The install side only
-/// registers this hook for the `Execute` matcher (Droid's shell tool), so
-/// grep/bash-shaped commands are the only calls that ever reach this
-/// handler; sub-agent/task launches are never routed here because Droid's
-/// sub-agent tool name is unconfirmed in Factory's public docs,
-/// and this hook fails open for anything it isn't told to inspect.
+/// Kiro uses (not Claude's stdout JSON decision). The install side registers
+/// this hook for the `^(Execute|Grep)$` matcher, so a symbol-shaped shell
+/// `grep`/`rg`/`ag` (`Execute`) and a symbol-shaped `Grep` `pattern` on a code
+/// target are the only calls that ever reach this handler; `Read`/`LS`/`Glob`
+/// and sub-agent/task launches are never routed here (see the matcher doc in
+/// `agents/droid.rs`), and this hook fails open for anything it isn't told to
+/// inspect.
 pub fn hook_droid_pre_tool_use() -> i32 {
     let event = read_stdin_to_string();
     if let Some(reason) = evaluate_droid_pre_tool_use(&event) {

--- a/tests/droid_agent_test.rs
+++ b/tests/droid_agent_test.rs
@@ -428,8 +428,8 @@ fn test_install_writes_pre_tool_use_hook() {
     let entries = config["hooks"]["PreToolUse"].as_array().unwrap();
     let entry = entries
         .iter()
-        .find(|e| e["matcher"].as_str() == Some("Execute"))
-        .expect("an Execute-matcher entry should be present");
+        .find(|e| e["matcher"].as_str() == Some("^(Execute|Grep)$"))
+        .expect("an ^(Execute|Grep)$-matcher entry should be present");
     let command = entry["hooks"][0]["command"].as_str().unwrap();
     assert!(
         command.contains("/usr/local/bin/tokensave"),
@@ -498,11 +498,11 @@ fn test_install_preserves_existing_hooks_and_settings() {
     assert!(
         pre_tool_use
             .iter()
-            .any(|e| e["matcher"].as_str() == Some("Execute")
+            .any(|e| e["matcher"].as_str() == Some("^(Execute|Grep)$")
                 && e["hooks"][0]["command"]
                     .as_str()
                     .is_some_and(|c| c.contains("tokensave"))),
-        "tokensave's Execute-matcher hook should be added"
+        "tokensave's ^(Execute|Grep)$-matcher hook should be added"
     );
     assert_eq!(
         config["hooks"]["Stop"][0]["hooks"][0]["command"]
@@ -510,6 +510,63 @@ fn test_install_preserves_existing_hooks_and_settings() {
             .unwrap(),
         "/opt/owner/stop.sh",
         "unrelated hook event should be untouched"
+    );
+}
+
+#[test]
+fn test_install_preserves_foreign_hook_with_lookalike_command() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let path = settings_path(home);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &path,
+        r#"{
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Grep",
+                        "hooks": [{"type": "command", "command": "/opt/hooks/tokensave-helper hook-droid-pre-tool-use"}]
+                    },
+                    {
+                        "matcher": "Grep",
+                        "hooks": [{"type": "command", "command": "/usr/local/bin/tokensave hook-droid-pre-tool-use --custom"}]
+                    }
+                ]
+            }
+        }"#,
+    )
+    .unwrap();
+
+    DroidIntegration.install(&make_ctx(home)).unwrap();
+
+    let config = read_json(&path);
+    let entries = config["hooks"]["PreToolUse"].as_array().unwrap();
+    assert!(
+        entries.iter().any(|e| {
+            e["hooks"][0]["command"].as_str()
+                == Some("/opt/hooks/tokensave-helper hook-droid-pre-tool-use")
+        }),
+        "a foreign hook using a lookalike binary must survive install"
+    );
+    assert!(
+        entries.iter().any(|e| {
+            e["hooks"][0]["command"].as_str()
+                == Some("/usr/local/bin/tokensave hook-droid-pre-tool-use --custom")
+        }),
+        "a customized command with trailing arguments must survive install"
+    );
+    assert_eq!(
+        entries
+            .iter()
+            .filter(|e| {
+                e["hooks"][0]["command"]
+                    .as_str()
+                    .is_some_and(|c| c.ends_with("tokensave hook-droid-pre-tool-use"))
+            })
+            .count(),
+        1,
+        "tokensave's hook should be installed separately"
     );
 }
 
@@ -536,6 +593,95 @@ fn test_install_hook_idempotent() {
         count, 1,
         "tokensave's hook entry should appear exactly once"
     );
+}
+
+#[test]
+fn test_install_migrates_stale_execute_only_matcher() {
+    // An install written by an older tokensave used the `Execute`-only matcher.
+    // Re-installing must upgrade it in place to `^(Execute|Grep)$`, not leave a
+    // duplicate entry that would fire the hook twice.
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let path = settings_path(home);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &path,
+        r#"{
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Execute",
+                        "hooks": [{"type": "command", "command": "/usr/local/bin/tokensave hook-droid-pre-tool-use"}]
+                    }
+                ]
+            }
+        }"#,
+    )
+    .unwrap();
+
+    let ctx = make_ctx(home);
+    DroidIntegration.install(&ctx).unwrap();
+
+    let config = read_json(&path);
+    let entries = config["hooks"]["PreToolUse"].as_array().unwrap();
+    let tokensave_entries: Vec<_> = entries
+        .iter()
+        .filter(|e| {
+            e["hooks"][0]["command"]
+                .as_str()
+                .is_some_and(|c| c.contains("hook-droid-pre-tool-use"))
+        })
+        .collect();
+    assert_eq!(
+        tokensave_entries.len(),
+        1,
+        "stale entry must be migrated in place, not duplicated"
+    );
+    assert_eq!(
+        tokensave_entries[0]["matcher"].as_str(),
+        Some("^(Execute|Grep)$"),
+        "matcher should be upgraded to the widened value"
+    );
+}
+
+#[test]
+fn test_uninstall_removes_stale_execute_only_matcher() {
+    // uninstall must recognize a tokensave entry by its subcommand even when
+    // the matcher is the older `Execute`-only value.
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let path = settings_path(home);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &path,
+        r#"{
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Execute",
+                        "hooks": [{"type": "command", "command": "/usr/local/bin/tokensave hook-droid-pre-tool-use"}]
+                    }
+                ]
+            }
+        }"#,
+    )
+    .unwrap();
+
+    let ctx = make_ctx(home);
+    DroidIntegration.uninstall(&ctx).unwrap();
+
+    // The only hook was tokensave's, so uninstall empties and removes the file.
+    let still_present = path.exists()
+        && read_json(&path)["hooks"]["PreToolUse"]
+            .as_array()
+            .is_some_and(|arr| {
+                arr.iter().any(|e| {
+                    e["hooks"][0]["command"]
+                        .as_str()
+                        .is_some_and(|c| c.contains("hook-droid-pre-tool-use"))
+                })
+            });
+    assert!(!still_present, "stale Execute-only entry should be removed");
 }
 
 #[test]
@@ -621,6 +767,30 @@ fn test_healthcheck_detects_missing_hook() {
     };
     DroidIntegration.healthcheck(&mut dc, &hctx);
     assert!(dc.issues > 0, "healthcheck should detect missing hook");
+}
+
+#[test]
+fn test_healthcheck_detects_stale_execute_only_matcher() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_ctx(home);
+    DroidIntegration.install(&ctx).unwrap();
+
+    let path = settings_path(home);
+    let mut config = read_json(&path);
+    config["hooks"]["PreToolUse"][0]["matcher"] = serde_json::json!("Execute");
+    std::fs::write(&path, serde_json::to_string_pretty(&config).unwrap()).unwrap();
+
+    let mut dc = DoctorCounters::new();
+    let hctx = HealthcheckContext {
+        home: home.to_path_buf(),
+        project_path: home.to_path_buf(),
+    };
+    DroidIntegration.healthcheck(&mut dc, &hctx);
+    assert!(
+        dc.issues > 0,
+        "healthcheck should require the current matcher so users know to reinstall"
+    );
 }
 
 #[test]

--- a/tests/hooks_test.rs
+++ b/tests/hooks_test.rs
@@ -317,14 +317,25 @@ fn test_kiro_allows_invalid_json() {
 
 #[test]
 fn test_grep_blocks_bare_symbol_on_rust_file() {
-    let input = r#"{"pattern": "FooBar", "path": "src/main.rs"}"#;
+    let input = r#"{"pattern": "FooBar", "path": "src/main.rs", "output_mode": "content"}"#;
     let result = evaluate_hook_decision_with_env(input, &env_indexed());
     assert!(is_blocked(&result), "bare symbol on .rs should redirect");
 }
 
 #[test]
+fn test_grep_allows_omitted_output_mode() {
+    let input = r#"{"pattern": "FooBar", "path": "src/main.rs"}"#;
+    let result = evaluate_hook_decision_with_env(input, &env_indexed());
+    assert!(
+        result.is_empty(),
+        "the harness default is path-only, so only explicit content mode should redirect"
+    );
+}
+
+#[test]
 fn test_grep_blocks_alternation_on_rust_file() {
-    let input = r#"{"pattern": "Foo\\|Bar\\|Baz", "path": "src/main.rs"}"#;
+    let input =
+        r#"{"pattern": "Foo\\|Bar\\|Baz", "path": "src/main.rs", "output_mode": "content"}"#;
     let result = evaluate_hook_decision_with_env(input, &env_indexed());
     assert!(
         is_blocked(&result),
@@ -334,7 +345,8 @@ fn test_grep_blocks_alternation_on_rust_file() {
 
 #[test]
 fn test_grep_blocks_word_boundary_symbol() {
-    let input = r#"{"pattern": "\\bhandle_request\\b", "path": "src/main.rs"}"#;
+    let input =
+        r#"{"pattern": "\\bhandle_request\\b", "path": "src/main.rs", "output_mode": "content"}"#;
     let result = evaluate_hook_decision_with_env(input, &env_indexed());
     assert!(is_blocked(&result), "\\bsymbol\\b should redirect");
 }
@@ -380,7 +392,7 @@ fn test_grep_allows_count_mode() {
 
 #[test]
 fn test_grep_blocks_on_directory_path_when_indexed() {
-    let input = r#"{"pattern": "FooBar", "path": "src/"}"#;
+    let input = r#"{"pattern": "FooBar", "path": "src/", "output_mode": "content"}"#;
     let result = evaluate_hook_decision_with_env(input, &env_indexed());
     assert!(
         is_blocked(&result),
@@ -390,7 +402,7 @@ fn test_grep_blocks_on_directory_path_when_indexed() {
 
 #[test]
 fn test_grep_blocks_when_only_glob_set() {
-    let input = r#"{"pattern": "FooBar", "glob": "**/*.rs"}"#;
+    let input = r#"{"pattern": "FooBar", "glob": "**/*.rs", "output_mode": "content"}"#;
     let result = evaluate_hook_decision_with_env(input, &env_indexed());
     assert!(is_blocked(&result), "glob over .rs should redirect");
 }
@@ -404,14 +416,14 @@ fn test_grep_allows_glob_for_non_code() {
 
 #[test]
 fn test_grep_blocks_with_type_filter_rust() {
-    let input = r#"{"pattern": "FooBar", "type": "rust"}"#;
+    let input = r#"{"pattern": "FooBar", "type": "rust", "output_mode": "content"}"#;
     let result = evaluate_hook_decision_with_env(input, &env_indexed());
     assert!(is_blocked(&result), "type=rust should redirect");
 }
 
 #[test]
 fn test_grep_block_message_names_tokensave_tool() {
-    let input = r#"{"pattern": "FooBar", "path": "src/main.rs"}"#;
+    let input = r#"{"pattern": "FooBar", "path": "src/main.rs", "output_mode": "content"}"#;
     let result = evaluate_hook_decision_with_env(input, &env_indexed());
     let reason = get_block_reason(&result);
     assert!(
@@ -570,7 +582,7 @@ fn test_bash_allows_when_env_override() {
 #[test]
 fn test_disable_env_bypasses_every_redirect_path() {
     let cases = [
-        r#"{"pattern": "FooBar", "path": "src/main.rs"}"#,
+        r#"{"pattern": "FooBar", "path": "src/main.rs", "output_mode": "content"}"#,
         r#"{"command": "grep -n FooBar src/main.rs"}"#,
         r#"{"subagent_type": "Explore", "prompt": "find all API endpoints"}"#,
         r#"{"prompt": "explore the codebase and map the call graph"}"#,
@@ -677,10 +689,10 @@ fn test_claude_allows_invalid_json() {
 // with the tool payload nested under `tool_input` (the Claude/Kiro shape),
 // but the block is signaled via the raw reason text (`hook_droid_pre_tool_use`
 // prints it to stderr and exits 2 — the Kiro mechanism), not a stdout JSON
-// object. Only the `Execute` matcher is installed (§ANALYSIS-droid-hooks.md
-// GAP 2), so only grep/bash-shaped `command` payloads reach this handler in
-// practice; the shared decision core is still exercised directly below for
-// the sub-agent-shaped payload in case that matcher ever widens.
+// object. The `^(Execute|Grep)$` matcher is installed, so grep/bash-shaped
+// `command` payloads and Droid's native `Grep` `pattern` payloads reach this
+// handler; the shared decision core is still exercised directly below for the
+// sub-agent-shaped payload, which no installed matcher routes here.
 // ============================================================================
 
 #[test]
@@ -757,10 +769,10 @@ fn test_droid_respects_disable_grep_hook_escape_hatch() {
 fn test_droid_specialized_subagent_with_normal_task_passes() {
     // A specialized sub-agent given a normal (non-research) task must not be
     // blocked. Droid's own sub-agent/task launch tool name is unconfirmed in
-    // Factory's public docs, so today such a call never reaches this hook at
-    // all (only "Execute" is a registered matcher) — this test guards the
-    // shared decision core directly in case that matcher scope ever widens to
-    // cover a delegation tool.
+    // Factory's public docs, so today such a call never reaches this hook
+    // (`^(Execute|Grep)$` is the registered matcher). This test guards the
+    // shared decision core directly in case that matcher scope widens to cover
+    // a delegation tool.
     let input = r#"{
         "subagent_type": "implementer",
         "prompt": "Implement the retry logic for the sync client and add tests"
@@ -794,4 +806,93 @@ fn test_droid_block_reason_documents_escape_hatch() {
     }"#;
     let reason = evaluate_droid_pre_tool_use_with_env(input, &env_indexed()).unwrap();
     assert!(reason.contains("TOKENSAVE_DISABLE_GREP_HOOK"));
+}
+
+// ---------------------------------------------------------------------------
+// Droid native `Grep` tool payloads. The `Grep` matcher routes these through
+// the same shared decision core as the Claude `Grep` tool, but Droid names two
+// fields differently (`glob_pattern` not `glob`; `file_paths` not
+// `files_with_matches`), so these guard that the classifier reads both shapes.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_droid_native_grep_omitted_output_mode_passes() {
+    let input = r#"{
+        "tool_name": "Grep",
+        "tool_input": {"pattern": "handle_request", "path": "src"}
+    }"#;
+    let reason = evaluate_droid_pre_tool_use_with_env(input, &env_indexed());
+    assert!(
+        reason.is_none(),
+        "omitted output_mode uses Droid's path-only default and should pass"
+    );
+}
+
+#[test]
+fn test_droid_native_grep_uses_glob_pattern_field() {
+    // Droid's Grep field is `glob_pattern`, not Claude's `glob`.
+    let on_code = r#"{
+        "tool_name": "Grep",
+        "tool_input": {"pattern": "FooBar", "glob_pattern": "**/*.rs", "output_mode": "content"}
+    }"#;
+    assert!(
+        evaluate_droid_pre_tool_use_with_env(on_code, &env_indexed()).is_some(),
+        "glob_pattern over .rs should redirect"
+    );
+
+    let on_docs = r#"{
+        "tool_name": "Grep",
+        "tool_input": {"pattern": "FooBar", "glob_pattern": "**/*.md", "output_mode": "content"}
+    }"#;
+    assert!(
+        evaluate_droid_pre_tool_use_with_env(on_docs, &env_indexed()).is_none(),
+        "glob_pattern over .md should pass through"
+    );
+}
+
+#[test]
+fn test_droid_native_grep_file_paths_mode_passes() {
+    // `file_paths` returns only names (Droid's cheap mode) — nothing to save.
+    let input = r#"{
+        "tool_name": "Grep",
+        "tool_input": {"pattern": "handle_request", "path": "src", "output_mode": "file_paths"}
+    }"#;
+    assert!(
+        evaluate_droid_pre_tool_use_with_env(input, &env_indexed()).is_none(),
+        "file_paths output mode should pass through"
+    );
+}
+
+#[test]
+fn test_droid_native_grep_content_mode_blocks() {
+    let input = r#"{
+        "tool_name": "Grep",
+        "tool_input": {"pattern": "handle_request", "path": "src", "output_mode": "content"}
+    }"#;
+    assert!(
+        evaluate_droid_pre_tool_use_with_env(input, &env_indexed()).is_some(),
+        "content output mode over code should redirect"
+    );
+}
+
+#[test]
+fn test_droid_native_grep_non_code_target_passes() {
+    let input = r#"{
+        "tool_name": "Grep",
+        "tool_input": {"pattern": "TODO", "glob_pattern": "**/*.md", "output_mode": "content"}
+    }"#;
+    assert!(evaluate_droid_pre_tool_use_with_env(input, &env_indexed()).is_none());
+}
+
+#[test]
+fn test_droid_native_grep_respects_escape_hatch() {
+    let input = r#"{
+        "tool_name": "Grep",
+        "tool_input": {"pattern": "handle_request", "path": "src", "output_mode": "content"}
+    }"#;
+    assert!(evaluate_droid_pre_tool_use_with_env(input, &env_indexed()).is_some());
+    assert!(
+        evaluate_droid_pre_tool_use_with_env(input, &env_disabled()).is_none(),
+        "TOKENSAVE_DISABLE_GREP_HOOK=1 must let the native Grep call through"
+    );
 }


### PR DESCRIPTION
## Summary

- Widen the Droid `PreToolUse` install matcher from `Execute` to `^(Execute|Grep)$` (an anchored regex, verified live to still fire on both tools), so a symbol-shaped `pattern` routed through Droid's **native `Grep` tool** (previously invisible to the guardrail) redirects to `tokensave_search`/`tokensave_callers_for`, reaching parity with the Claude hook's Grep coverage.
- The shared core (`evaluate_hook_decision_core`) already classifies a `pattern` payload. It now reads `glob_pattern` alongside Claude's `glob`, and redirects only an explicit `output_mode: "content"`. Omitted, malformed, unknown, and cheap path-only modes pass through, matching both harness defaults and covering Droid's `file_paths` without guessing that an undeclared search requested content.
- Re-installing over an older `Execute`-only entry migrates it in place (matched by the exact binary/subcommand command shape, not matcher value) instead of leaving a duplicate that would fire the hook twice. Lookalike binaries and customized commands with trailing arguments remain foreign.
- Implements the design of https://github.com/aovestdipaperino/tokensave/issues/251

## Motivation

`rnoz/droid-hooks` shipped the Droid `PreToolUse` guardrail but registered only the `Execute` matcher (Droid's shell tool), deliberately staying fail-open while the integration was validated. That leaves Droid's own `Grep` tool unguarded: a symbol-shaped `Grep` on a code file returns raw match lines where a symbol lookup would return a compact list. Measured this session on this repo: `tokensave_search "..."` reported `before=5172 after=67` tokens for a symbol query. `Grep` is the one remaining redirectable tool where Droid is behind Claude.

## Design Decision: Why `Grep`, and only `Grep` (per-tool analysis)

Droid's hook contract is a **hard block** (exit 2 + stderr). There is no confirmed "suggest but allow" (soft-steer) channel like Claude's `additionalContext`. So every matcher we add can only *deny* a call and force the agent elsewhere. A block is a net win only when all three hold: (1) tokensave has a non-lossy equivalent, (2) the classifier can tell *this* call is redirectable with high precision, (3) blocking doesn't strand the agent.

| Tool | tokensave equiv | Classify intent? | Hard-block safe? | Verdict |
|---|---|---|---|---|
| **Grep** | `tokensave_search`/`callers_for`, non-lossy | Yes: identifier-shaped pattern + code target + indexed project | Yes: names exact tool + escape hatch | **Ship** |
| Read | `node`/`body` need a *symbol*; Read gives a *path*; also hits md/json/`.env` | No | No, strands legit reads; needs soft-steer | Defer |
| LS | `tokensave_files` (indexed only, no size/mtime) | n/a | No, LS already cheap, equiv lossy | Defer |
| Glob | `tokensave_files --pattern` (partial) | No symbol signal (paths, not content) | Low reward | Defer |
| Task | only *research* tasks; core blocks `Explore`/untyped | Droid Task always **typed** → classifier ~never fires | Harmless no-op | Skip |

**Parity, not subpar.** Claude's core redirects three shapes: Grep-`pattern`, Bash-grep-`command`, and its `Explore` agent. Droid already covers Bash-grep (via `Execute`) and has no `Explore` agent to match. So `Execute + Grep` = everything Claude's core does that is relevant to Droid.

**Execute pipe-chain rewriting is out of scope (and likely rtk-land).** The hook allows/blocks a whole `Execute`; it never rewrites. Decomposing `cd && git log | grep ...` into stages to block inner greps is fragile shell parsing, and arbitrary-command interception is arguably rtk's domain. The pending grep-target issues already frame ownership as "may belong in rtk, not tokensave."

## Changes

- **`src/agents/droid.rs`**
  - `DROID_HOOK_MATCHER`: `"Execute"` → `"^(Execute|Grep)$"` (Factory treats the value as a regex; the pattern is anchored so it matches only those exact tool names, not a future name that merely contains `Execute`/`Grep`, and was verified live to still fire on both). Doc comment now records the per-tool rationale, the anchoring reason, and the deliberate exclusions.
  - New `is_tokensave_droid_hook(entry)` helper: identifies our hook by an exact tokensave binary plus `hook-droid-pre-tool-use` subcommand rather than the matcher value, so an older `Execute`-only install is recognized without claiming a foreign lookalike wrapper.
  - `install_hook` now **upserts**: if a tokensave entry with the current matcher exists it skips; otherwise it drops any existing tokensave entry (migrating a stale matcher) and appends the current one, preserving every non-tokensave hook. `uninstall_hook` uses the same ownership check. `doctor_check_hook` recognizes the owned entry but separately requires the current matcher, so an older `Execute`-only install is reported as stale instead of healthy.
- **`src/hooks.rs`**
  - `evaluate_grep_tool_input`: read `glob_pattern` as a fallback for `glob`; redirect only explicit content mode so omitted/default, malformed, unknown, and path-only modes fail open. The Droid handler doc comment now notes `Grep` reaches it.
- **`tests/hooks_test.rs`**: +6 Droid native-`Grep` cases (omitted/default mode passes; explicit content on code blocks; `glob_pattern` on `.rs` blocks and on `.md` passes; `file_paths` passes; non-code passes; escape hatch) plus a shared omitted-mode regression.
- **`tests/droid_agent_test.rs`**: existing matcher assertions updated to `^(Execute|Grep)$`; +4 lifecycle cases (stale `Execute`-only entry upgraded in place with no duplicate; uninstall removes a stale entry; foreign lookalike and trailing-argument commands survive install; `doctor` rejects a stale matcher).

## Test plan

- [x] `cargo test --test hooks_test`: 85 passed, 0 failed (+6 Droid Grep cases plus the shared omitted-mode regression; all prior cases unchanged).
- [x] `cargo test --test droid_agent_test`: 30 passed, 0 failed (+4 lifecycle cases; matcher assertions updated to the anchored value).
- [x] `cargo test --test mcp_handler_test`: 174 passed, 0 failed.
- [x] `cargo test` (full workspace): 2,469 passed across 96 suites, 0 failed.
- [x] `cargo clippy --workspace --all-targets`: clean.
- [x] `cargo fmt --all -- --check`: clean.
- [x] Real `droid exec` session (see "Real-world verification" below): Factory fires `PreToolUse` for the native `Grep` tool under both the unanchored and the shipped anchored `^(Execute|Grep)$` matcher; a symbol `Grep` on `src` blocks (exit 2), the block is deterministic on retry, and the model self-recovers (escape hatch, then a plain read); the escape hatch, a non-code `glob_pattern`, and `file_paths` mode all pass through.

### Real-world verification

Testing the anchored matcher. Method: the branch's own `cargo build --release` binary; a scratch project (`/tmp/droid-grep-verify`) indexed with `tokensave init` whose `src/main.rs` defines `handle_request_for_widget`; `tokensave install --agent droid --local` (which writes matcher `^(Execute|Grep)$`); and `droid exec --model minimax-m3 --skip-permissions-unsafe --cwd <scratch>`. The scratch `AGENTS.md` was emptied so the model reaches for the native `Grep` tool rather than being told to use tokensave. Excerpts below are verbatim from the session output.

**The premise this validated:** Factory runs `PreToolUse` hooks for the native `Grep` tool, not only `Execute`, and honors an anchored regex matcher. The block fired identically under the unanchored `Execute|Grep` and the shipped anchored `^(Execute|Grep)$` value, confirming anchoring does not stop the hook from matching the `Grep` tool name.

#### Test A, native `Grep` on a code dir is blocked, model self-recovers

`Grep {pattern:"handle_request_for_widget", path:".../src", output_mode:"content", line_numbers:true}`. The model's verbatim report:

> The native `Grep` tool was intercepted by a project `PreToolUse` hook installed by the `tokensave` MCP installer. [...] `STOP: This Grep targets a code file in a tokensave-indexed project and the pattern handle_request_for_widget looks like a symbol name. Use tokensave_search (definition) or tokensave_callers_for (usages) instead [...] set TOKENSAVE_DISABLE_GREP_HOOK=1 in the shell.` I retried the same `Grep` call once more to confirm the block is deterministic; same verbatim error.

The model then abandoned `Grep`: it ran `Execute` with `TOKENSAVE_DISABLE_GREP_HOOK=1 grep -rn handle_request_for_widget src` (the override the message names) and a `Read`, and noted `tokensave_search` as the project's preferred lookup. Both a `worker`-shaped recovery and the escape hatch are exercised; the block itself is the point.

#### Test A', anchored matcher still fires

Repeating Test A after rewriting the installed matcher to `^(Execute|Grep)$` produced the same block (STOP message, deterministic). This is the evidence behind shipping the anchored form: it is safer (no substring collision) and loses nothing (still matches `Grep` live).

#### Test B, escape hatch

With `TOKENSAVE_DISABLE_GREP_HOOK=1`, the same `Grep` call passes (exit 0). Seen both in the model run (its override grep ran and returned the two match lines) and in the direct-CLI matrix below.

#### Test C, control, non-code target passes

`Grep {pattern, glob_pattern:"**/*.md"}` passes through (confirms `glob_pattern` is read and a non-code target is not redirected).

#### Direct-CLI proof (no model spend), verbatim exit codes

Run from the indexed scratch project, piping Droid-shaped events into `tokensave hook-droid-pre-tool-use` (ambient `TOKENSAVE_DISABLE_GREP_HOOK` unset except the last row):

| Event | Exit |
|---|---|
| `Grep {pattern, path:"src"}` (no `output_mode`) | 0 |
| `Grep {pattern, glob_pattern:"**/*.rs", output_mode:"content"}` | 2 |
| `Grep {pattern, glob_pattern:"**/*.md", output_mode:"content"}` | 0 |
| `Grep {pattern:"TODO", path:".", glob_pattern:"**/*.md", output_mode:"content"}` | 2 (known shared classifier bug, split to `grep-path-glob-precedence`) |
| `Grep {pattern, path:"src", output_mode:"file_paths"}` | 0 |
| `Grep {pattern, path:"src", output_mode:"content"}` | 2 |
| `Execute {command:"grep -rn <symbol> src/main.rs"}` | 2 |
| `Grep {pattern, path:"src"}` with `TOKENSAVE_DISABLE_GREP_HOOK=1` | 0 |

The first row follows Droid's path-only default. Only an explicit `content` request is eligible for redirection. The `path` + Markdown-glob false-positive is documented rather than hidden, and is queued as the next narrow shared-classifier fix before the `explorer` matcher follow-up.

#### Notes from the run

- **The block is independent of AGENTS.md rules.** The scratch project's `AGENTS.md` was emptied and the model was told to use `Grep`; it still got exit
  2. So the guardrail does not rely on prompt-rule discipline, it enforces at the tool boundary.
- **Recovery path depends on what the project offers.** In this rules-free scratch (no tokensave MCP registered, empty AGENTS.md) the model recovered via the named escape hatch (`TOKENSAVE_DISABLE_GREP_HOOK=1` + `Execute` grep) and a `Read`, and explicitly noted `tokensave_search` as the preferred lookup. In a real project with the tokensave MCP server and AGENTS rules present, the model goes straight to `tokensave_search`/`tokensave_callers_for`.
- **Install in a single scope to avoid a double-fire.** Factory merges every settings source and runs each one, so the same logical hook installed in *both* `~/.factory/settings.json` (global) and `<repo>/.factory/settings.json` (project) fires twice. This is not a tokensave defect (each file holds one entry) nor a Factory defect (running each configured source is reasonable); keep the hook in one scope. Both invocations return identical results, so there is no functional impact meanwhile.
- **Token framing.** The redirect replaces a `content` grep with a compact symbol lookup; on this repo a real `tokensave_search` reported `before=5172 after=67` tokens for a symbol query. The win scales with file/match size, not the 8-line scratch fixture.


## Checklist

- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [x] No secrets, credentials, or `.env` files included
- [x] Breaking changes documented (none; additive matcher widening + a migrating install that removes a duplicate an older version could have left)

