### PR TITLE
ci: drop the star-triggered run from the Star History workflow (#265)

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -3,11 +3,13 @@ name: Star History
 # Regenerates the README star history chart in CI. Needed since GitHub's
 # 2026-06-30 stargazers API restriction broke the hosted star-history.com
 # embed; this runs with the repo's own token, which can still read stars.
+# No `watch` trigger: a star-triggered run is attributed to the stargazer,
+# so when the run fails (e.g. expired STAR_HISTORY_TOKEN) GitHub emails the
+# failure to that third party (#265). The daily schedule keeps the chart
+# fresh enough.
 on:
   schedule:
     - cron: '17 4 * * *' # daily
-  watch:
-    types: [started] # refresh right after a new star
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Remove the `watch: types: [started]` trigger from `.github/workflows/star-history.yml`, keeping the daily schedule and `workflow_dispatch`.

## Why
A star-triggered run is attributed to the stargazer, so when the workflow fails, GitHub emails the failure notice to that third party — which is exactly how #265 was filed. Every run since 2026-07-23 ~11:33 UTC fails on its first stargazers request with `403 GitHub API rate limit exceeded`; that's an auth failure in disguise (it never recovers hourly): the `STAR_HISTORY_TOKEN` fine-grained PAT stopped being accepted that morning.

Two independent fixes:
1. The PAT is being rotated separately (repo secret, not part of this diff).
2. This PR removes the trigger class so no future token expiry can ever email a random stargazer again. Scheduled-run failures notify the workflow author instead. The only loss is the instant chart refresh on a new star, which the daily schedule makes cosmetic.

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)