### PR TITLE
fix(extraction): build .gdshader signatures from the original source, not the dialect-blanked copy (#272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [maintenance-based versioning](TOKENSAVE-VERSIONING.md), not SemVer.
 
+## [Unreleased]
+
+### Fixed
+- **`.gdshader` node signatures keep the original Godot hint/qualifier text instead of the blanked copy fed to the parser (#272).** The Godot-dialect support shipped in 7.6.1 (#270, #275) rewrites `: hint_…` clauses and `global`/`instance` qualifiers into same-length spaces so the vanilla GLSL grammar can parse the file — but it then extracted every node's signature and excerpt from that rewritten copy, so `uniform sampler2D albedo : source_color;` indexed with the hint text silently dropped from its signature. Extraction now parses the normalized copy while reading all node text from the original source — the two are byte-length- and line-identical by construction, so tree-sitter's byte ranges index both interchangeably — and a hinted or `global`/`instance` uniform's indexed signature shows the real declaration text. Ported from PR #272 by @janstol, whose independently developed `.gdshader` support crossed mid-air with #275; the surviving delta (original-source signatures, its regression fixture, and the `MORE-LANGUAGES-SUPPORT` documentation note) is landed here with attribution.
+
 ## [7.6.1] - 2026-07-24
 
 ### Added

--- a/docs/MORE-LANGUAGES-SUPPORT.md
+++ b/docs/MORE-LANGUAGES-SUPPORT.md
@@ -86,7 +86,7 @@ Languages with growing communities or specific ecosystem value.
 |----------|-----------|---------------|------------|-------|
 | **Gleam** | `.gleam` | `tree-sitter-gleam` (1.0.0) | Low-medium | Functions, types, imports, externals. Clean syntax, good graph potential. BEAM ecosystem. |
 | **Odin** | `.odin` | `tree-sitter-odin` (1.3.0) | Medium | Procedures, structs, enums, imports, packages. Systems programming language gaining traction. |
-| **GDScript** | `.gd` | `tree-sitter-gdscript` (6.1.0) | Medium | Classes, functions, signals, exports, `extends`. Godot engine scripting — large gamedev community. |
+| **GDScript** | `.gd` | `tree-sitter-gdscript` (6.1.0) | Medium | Classes, functions, signals, exports, `extends`. Godot engine scripting — large gamedev community. Godot's `.gdshader` shader files are indexed separately via the GLSL extractor (see Full tier above). |
 | **Solidity** | `.sol` | `tree-sitter-solidity` (1.2.13) | Medium | Contracts, functions, events, modifiers, inheritance. Contract→contract `extends` edges. Web3 niche but high demand. |
 | **Elm** | `.elm` | `tree-sitter-elm` (5.9.0) | Low-medium | Modules, functions, type aliases, custom types, ports, imports. Clean ML-like syntax. |
 | **Groovy** | `.groovy`, `.gradle` | `tree-sitter-groovy` (0.1.2) | Medium | Classes, methods, closures. `.gradle` files are Groovy — useful for build graph analysis. |

--- a/src/extraction/glsl_extractor.rs
+++ b/src/extraction/glsl_extractor.rs
@@ -27,10 +27,21 @@ struct GodotDirective {
 
 impl GlslExtractor {
     pub fn extract_source(file_path: &str, source: &str) -> ExtractionResult {
+        Self::extract_source_inner(file_path, source, source)
+    }
+
+    /// Extract from `parse_src` (a possibly dialect-normalized copy of
+    /// `source`) while reading all node text — signatures, excerpts,
+    /// docstrings — from the original `source`. The two must have identical
+    /// byte length and line structure so tree-sitter byte ranges index both
+    /// interchangeably; `rewrite_godot_dialect` guarantees this by blanking
+    /// with spaces. This keeps e.g. a `: hint_range(…)` clause visible in a
+    /// uniform's indexed signature even though the parser never sees it.
+    fn extract_source_inner(file_path: &str, source: &str, parse_src: &str) -> ExtractionResult {
         let start = Instant::now();
         let mut state = ExtractionState::new(file_path, source);
 
-        let tree = match Self::parse_source(source) {
+        let tree = match Self::parse_source(parse_src) {
             Ok(tree) => tree,
             Err(msg) => {
                 state.errors.push(msg);
@@ -95,7 +106,7 @@ impl GlslExtractor {
     /// nodes under the file.
     pub fn extract_gdshader(file_path: &str, source: &str) -> ExtractionResult {
         let (rewritten, directives) = Self::rewrite_godot_dialect(source);
-        let mut result = Self::extract_source(file_path, &rewritten);
+        let mut result = Self::extract_source_inner(file_path, source, &rewritten);
 
         let file_info = result
             .nodes

--- a/tests/fixtures/sample.gdshader
+++ b/tests/fixtures/sample.gdshader
@@ -1,0 +1,21 @@
+shader_type spatial;
+render_mode blend_mix, depth_draw_opaque, cull_back;
+
+#include "res://shaders/common.gdshaderinc"
+
+uniform sampler2D albedo : source_color;
+uniform float roughness_value : hint_range(0.0, 1.0) = 0.5;
+uniform vec4 tint_color;
+global uniform vec3 global_wind;
+instance uniform vec4 instance_tint;
+
+float compute_fresnel(float ndotv, float f0) {
+    return f0 + (1.0 - f0) * pow(1.0 - ndotv, 5.0);
+}
+
+void fragment() {
+    float fresnel = compute_fresnel(dot(NORMAL, VIEW), 0.04);
+    ALBEDO = texture(albedo, UV).rgb;
+    ROUGHNESS = roughness_value;
+    SPECULAR = fresnel;
+}

--- a/tests/glsl_extraction_test.rs
+++ b/tests/glsl_extraction_test.rs
@@ -431,6 +431,75 @@ fn test_gdshader_extracts_varying_and_const() {
     assert!(names.contains(&"PI"), "nodes: {names:?}");
 }
 
+// Ported from PR #272 (Jan Štol): signatures and excerpts must be built from
+// the ORIGINAL source, not the dialect-blanked copy that only exists to help
+// the parser — a hinted uniform's signature keeps its `: hint...` text.
+#[test]
+fn test_gdshader_signatures_keep_original_hint_text() {
+    let source = std::fs::read_to_string("tests/fixtures/sample.gdshader").unwrap();
+    let result = GlslExtractor.extract("sample.gdshader", &source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+    let const_nodes: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|n| n.kind == NodeKind::Const)
+        .collect();
+    let consts: Vec<_> = const_nodes.iter().map(|n| n.name.as_str()).collect();
+    for name in [
+        "albedo",
+        "roughness_value",
+        "tint_color",
+        "global_wind",
+        "instance_tint",
+    ] {
+        assert!(consts.contains(&name), "consts: {consts:?}");
+    }
+
+    let sig = |name: &str| -> String {
+        const_nodes
+            .iter()
+            .find(|n| n.name == name)
+            .unwrap()
+            .signature
+            .clone()
+            .unwrap_or_default()
+    };
+    assert!(
+        sig("albedo").contains("source_color"),
+        "signature: {:?}",
+        sig("albedo")
+    );
+    assert!(
+        sig("roughness_value").contains("hint_range(0.0, 1.0)"),
+        "signature: {:?}",
+        sig("roughness_value")
+    );
+    assert!(
+        sig("global_wind").contains("global"),
+        "signature: {:?}",
+        sig("global_wind")
+    );
+    assert!(
+        sig("instance_tint").contains("instance"),
+        "signature: {:?}",
+        sig("instance_tint")
+    );
+
+    let includes: Vec<_> = result
+        .unresolved_refs
+        .iter()
+        .filter(|r| r.reference_kind == EdgeKind::Uses)
+        .map(|r| r.reference_name.as_str())
+        .collect();
+    assert!(
+        includes
+            .iter()
+            .any(|name| name.contains("common.gdshaderinc")),
+        "includes: {includes:?}"
+    );
+}
+
 #[test]
 fn test_gdshader_registry_dispatch() {
     use tokensave::extraction::LanguageRegistry;


### PR DESCRIPTION
## Summary
Ports the surviving delta of #272 (@janstol) onto master, with the commit authored by @janstol.

#272's independently developed `.gdshader` support crossed mid-air with #275, but it got one thing right that #275 didn't: signatures/excerpts must come from the **original** source, not the length-preserving blanked copy that only exists to help the GLSL parser. On master, `uniform sampler2D albedo : source_color;` indexed with the hint text silently dropped from its signature.

## Change
- `extract_gdshader` now parses the normalized copy while the `ExtractionState` reads all node text from the original source — byte length and line structure are identical by construction, so tree-sitter byte ranges index both interchangeably.
- #272's regression fixture (`tests/fixtures/sample.gdshader`) and a signature-preservation test: pre-fix it fails with `signature: "uniform sampler2D albedo"`; post-fix hints (`source_color`, `hint_range(0.0, 1.0)`) and `global`/`instance` qualifiers survive in indexed signatures.
- #272's `docs/MORE-LANGUAGES-SUPPORT.md` note pointing `.gdshader` at the GLSL extractor.

## Verification
fmt clean, clippy clean, full suite and lite suite pass.

Supersedes and credits #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)