### PR TITLE
fix(search): apply queryignore to literal mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [maintenance-based versioning](TOKENSAVE-VERSIONING.md), not SemVer.
 
+## [Unreleased]
+
+### Fixed
+- **Literal search (`tokensave_search` with `literal: true`) now honors `.tokensave/queryignore` like the ranked path.** The literal branch returned before the ranked path's queryignore filter ran, so paths a project had explicitly suppressed (#116) still appeared in literal matches. The indexed file list is now filtered with the same patterns before scanning — the same gap-closure shape as the `path_include`/`path_exclude` literal-mode fix in #258.
+
 ## [7.6.2] - 2026-07-25
 
 ### Added

--- a/src/mcp/tools/handlers/graph.rs
+++ b/src/mcp/tools/handlers/graph.rs
@@ -176,6 +176,14 @@ async fn handle_literal_search(
     // `path_exclude` takes precedence, matching `filter_by_path_lists`.
     files = filter_by_path_lists(files, path_include, path_exclude, |f| f.path.as_str());
 
+    // Project-level query-ignore applies to literal mode too — it used to
+    // return before the ranked path's queryignore filter, so suppressed
+    // paths (vendored trees, changelogs) still leaked into literal hits.
+    let query_ignore = crate::config::load_query_ignore(project_root);
+    if !query_ignore.is_empty() {
+        files.retain(|f| !query_ignore.is_ignored(&f.path));
+    }
+
     let mut matches: Vec<Value> = Vec::new();
     let mut touched: Vec<String> = Vec::new();
 

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -155,6 +155,33 @@ async fn test_search_literal_finds_string_in_body() {
 }
 
 #[tokio::test]
+async fn test_search_literal_respects_queryignore() {
+    let (cg, _dir) = setup_project().await;
+    // Same query as test_search_literal_finds_string_in_body, but with the
+    // matching file suppressed via .tokensave/queryignore — literal mode must
+    // honor the project-level ignore just like the ranked path does.
+    let ts_dir = cg.project_root().join(".tokensave");
+    std::fs::create_dir_all(&ts_dir).unwrap();
+    std::fs::write(ts_dir.join("queryignore"), "utils\n").unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tokensave_search",
+        json!({"query": "Hello, {}!", "literal": true}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let text = extract_text(&result.value);
+    let parsed: Value = serde_json::from_str(text).unwrap();
+    assert_eq!(
+        parsed["count"], 0,
+        "queryignore-suppressed file must not appear in literal matches: {parsed}"
+    );
+}
+
+#[tokio::test]
 async fn test_search_literal_no_match_returns_empty() {
     let (cg, _dir) = setup_project().await;
     let result = handle_tool_call(


### PR DESCRIPTION
# fix(search): apply queryignore to literal mode

## Summary

- Literal search (`tokensave_search` with `literal: true`) now honors `.tokensave/queryignore`, matching the ranked search path.

## Motivation

The literal branch of `handle_search` returns before the ranked path's queryignore filter runs, so paths a project explicitly suppressed via `.tokensave/queryignore` (#116) still appear in literal matches — e.g. literal hits from a vendored tree or `CHANGELOG.md` that ranked search correctly suppresses. Same gap shape as the `path_include`/`path_exclude` literal-mode fix in #258.

## Changes

- `src/mcp/tools/handlers/graph.rs` — `handle_literal_search` filters the indexed file list with the project queryignore patterns before scanning, right after the existing `path_include`/`path_exclude` filter.
- `tests/mcp_handler_test.rs` — regression test: a queryignore pattern matching the fixture file drops the literal match that `test_search_literal_finds_string_in_body` otherwise finds.
- `CHANGELOG.md` — entry under `[Unreleased]`.

## Test plan

- [x] `cargo test` passes
- [x] `cargo clippy` has no new warnings (only pre-existing `git.rs:850` `map_or` lint on master)
- [x] Tested manually: on the tokensave repo itself, literal queries for strings present in `CHANGELOG.md` stop matching once the path is listed in `.tokensave/queryignore`

## Checklist

- [x] `CHANGELOG.md` updated (under `[Unreleased]` if no version bump)
- [x] No secrets, credentials, or `.env` files included
- [x] Breaking changes documented (if any) — none
