### PR TITLE
feat(context): show docstring first line for entry points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project uses [maintenance-based versioning](TOKENSAVE-VERSIONING.md), n
 
 ## [Unreleased]
 
+### Added
+- **`tokensave_context` entry points now show the first line of the symbol's docstring** beneath the signature. The one-line summary often answers the query outright, saving the follow-up code fetch; entries without a docstring are unchanged.
+
 ### Fixed
 - **Literal search (`tokensave_search` with `literal: true`) now honors `.tokensave/queryignore` like the ranked path.** The literal branch returned before the ranked path's queryignore filter ran, so paths a project had explicitly suppressed (#116) still appeared in literal matches. The indexed file list is now filtered with the same patterns before scanning — the same gap-closure shape as the `path_include`/`path_exclude` literal-mode fix in #258.
 

--- a/src/context/formatter.rs
+++ b/src/context/formatter.rs
@@ -81,6 +81,15 @@ pub fn format_context_as_markdown(context: &TaskContext) -> String {
             if let Some(ref sig) = node.signature {
                 let _ = writeln!(out, "  `{sig}`");
             }
+            // A docstring's first line often answers the question without a
+            // code fetch — cheap to include, expensive to omit.
+            if let Some(first) = node
+                .docstring
+                .as_deref()
+                .and_then(|doc| doc.lines().find(|line| !line.trim().is_empty()))
+            {
+                let _ = writeln!(out, "  {}", first.trim());
+            }
         }
         out.push('\n');
     }
@@ -298,6 +307,44 @@ mod tests {
         assert!(md.contains("#### my_fn (src/main.rs:2)"));
         assert!(md.contains("```rust"));
         assert!(md.contains("fn my_fn()"));
+    }
+
+    #[test]
+    fn test_entry_point_docstring_first_line_shown() {
+        let mut ctx = make_test_context();
+        ctx.entry_points = vec![Node {
+            id: "function:doc".to_string(),
+            kind: NodeKind::Function,
+            name: "documented".to_string(),
+            qualified_name: "src/lib.rs::documented".to_string(),
+            file_path: "src/lib.rs".to_string(),
+            start_line: 1,
+            attrs_start_line: 1,
+            end_line: 5,
+            start_column: 0,
+            end_column: 1,
+            signature: None,
+            docstring: Some("Parses the config file.\n\nLong detail here.".to_string()),
+            visibility: Visibility::Pub,
+            is_async: false,
+            branches: 0,
+            loops: 0,
+            returns: 0,
+            max_nesting: 0,
+            unsafe_blocks: 0,
+            unchecked_calls: 0,
+            assertions: 0,
+            cognitive_complexity: 0,
+            distinct_operators: 0,
+            distinct_operands: 0,
+            total_operators: 0,
+            total_operands: 0,
+            updated_at: 0,
+            parent_id: None,
+        }];
+        let md = format_context_as_markdown(&ctx);
+        assert!(md.contains("  Parses the config file."), "{md}");
+        assert!(!md.contains("Long detail here"), "{md}");
     }
 
     #[test]


### PR DESCRIPTION
# feat(context): show docstring first line for entry points

## Summary

- `tokensave_context` entry points show the first non-empty docstring line beneath the signature.

## Motivation

Entry points previously listed only name, kind, location, and signature. Docstrings are already extracted and indexed (`extract_docstrings` defaults to true) but never surfaced in context output — yet the one-line summary frequently answers the query outright, saving the follow-up `include_code` fetch or `tokensave_body` call. One line per entry point is a small token cost against a whole avoided round-trip.

## Changes

- `src/context/formatter.rs` — `format_context_as_markdown` prints the first non-empty docstring line (trimmed) after the signature line; entries without a docstring are unchanged.
- Test asserts the first line appears and later lines don't.
- `CHANGELOG.md` — entry under `[Unreleased]`.

## Test plan

- [x] `cargo test` passes
- [x] `cargo clippy` has no new warnings (only pre-existing `git.rs:850` `map_or` lint on master)
- [x] Tested manually: `tokensave tool context` on this repo shows doc summaries under each documented entry point

## Checklist

- [x] `CHANGELOG.md` updated (under `[Unreleased]` if no version bump)
- [x] No secrets, credentials, or `.env` files included
- [x] Breaking changes documented (if any) — none