### PR TITLE
feat(context): point truncated code blocks at tokensave_body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project uses [maintenance-based versioning](TOKENSAVE-VERSIONING.md), n
 ### Added
 - **`tokensave_context` entry points now show the first line of the symbol's docstring** beneath the signature. The one-line summary often answers the query outright, saving the follow-up code fetch; entries without a docstring are unchanged.
 
+### Changed
+- **Truncated `tokensave_context` code blocks now end with a follow-up handle instead of a dead-end ellipsis.** A snippet cut at `max_code_block_size` closes with `... [truncated — full body: tokensave_body node_id=<id>]`, so the caller can fetch the remainder in one call rather than re-deriving which symbol the fragment belonged to.
+
 ### Fixed
 - **Literal search (`tokensave_search` with `literal: true`) now honors `.tokensave/queryignore` like the ranked path.** The literal branch returned before the ranked path's queryignore filter ran, so paths a project had explicitly suppressed (#116) still appeared in literal matches. The indexed file list is now filtered with the same patterns before scanning — the same gap-closure shape as the `path_include`/`path_exclude` literal-mode fix in #258.
 

--- a/src/context/builder.rs
+++ b/src/context/builder.rs
@@ -708,21 +708,7 @@ impl<'a> ContextBuilder<'a> {
             }
 
             if let Some(code) = self.get_code_cached(node, file_cache) {
-                let truncated = if code.len() > options.max_code_block_size {
-                    let prefix =
-                        crate::text::utf8_prefix_at_or_before(&code, options.max_code_block_size);
-                    // Prefer a line boundary within the truncated prefix, and
-                    // leave the caller a handle to fetch the rest instead of
-                    // a dead-end ellipsis.
-                    let end = prefix.rfind('\n').unwrap_or(prefix.len());
-                    format!(
-                        "{}\n... [truncated — full body: tokensave_body node_id={}]",
-                        &prefix[..end],
-                        node.id
-                    )
-                } else {
-                    code
-                };
+                let truncated = truncate_code_block(&code, options.max_code_block_size, &node.id);
 
                 blocks.push(CodeBlock {
                     content: truncated,
@@ -1383,6 +1369,24 @@ fn apply_per_file_cap(
     accepted
 }
 
+/// Truncates a code snippet to `max_size`, preferring a line boundary.
+///
+/// A truncated snippet closes with a `tokensave_body` handle rather than a bare
+/// ellipsis, so the caller can fetch the remainder in one follow-up call instead
+/// of re-deriving which symbol the fragment came from. Snippets at or under
+/// `max_size` are returned unchanged.
+fn truncate_code_block(code: &str, max_size: usize, node_id: &str) -> String {
+    if code.len() <= max_size {
+        return code.to_string();
+    }
+    let prefix = crate::text::utf8_prefix_at_or_before(code, max_size);
+    let end = prefix.rfind('\n').unwrap_or(prefix.len());
+    format!(
+        "{}\n... [truncated — full body: tokensave_body node_id={node_id}]",
+        &prefix[..end]
+    )
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::float_cmp)]
 mod tests {
@@ -1604,5 +1608,35 @@ mod tests {
         let names: Vec<_> = result.iter().map(|node| node.name.as_str()).collect();
         assert!(names.contains(&"run_solver"), "selected roots: {names:?}");
         assert!(names.contains(&"helper"), "selected roots: {names:?}");
+    }
+
+    #[test]
+    fn test_truncated_code_block_points_at_tokensave_body() {
+        let code = "fn wide() {\n".to_string() + &"    line();\n".repeat(50);
+        let out = truncate_code_block(&code, 60, "abc123");
+        assert!(
+            out.contains("tokensave_body node_id=abc123"),
+            "truncated block must carry a follow-up handle: {out}"
+        );
+        assert!(out.starts_with("fn wide() {"), "{out}");
+        // Truncation still lands on a line boundary, not mid-line.
+        let body = out.split("\n... [truncated").next().unwrap();
+        assert!(!body.ends_with("    line"), "cut mid-line: {body:?}");
+    }
+
+    #[test]
+    fn test_short_code_block_is_returned_verbatim() {
+        let code = "fn small() {}\n";
+        assert_eq!(truncate_code_block(code, 1500, "abc123"), code);
+        // Exactly at the limit is not truncation.
+        assert_eq!(truncate_code_block(code, code.len(), "abc123"), code);
+    }
+
+    #[test]
+    fn test_truncate_code_block_does_not_split_multibyte_char() {
+        // A multi-byte char straddling the cutoff must not panic or corrupt.
+        let code = "fn f() {\n    // ✅✅✅✅✅✅✅✅✅✅\n    body();\n}\n";
+        let out = truncate_code_block(code, 20, "n1");
+        assert!(out.contains("tokensave_body node_id=n1"), "{out}");
     }
 }

--- a/src/context/builder.rs
+++ b/src/context/builder.rs
@@ -711,9 +711,15 @@ impl<'a> ContextBuilder<'a> {
                 let truncated = if code.len() > options.max_code_block_size {
                     let prefix =
                         crate::text::utf8_prefix_at_or_before(&code, options.max_code_block_size);
-                    // Prefer a line boundary within the truncated prefix.
+                    // Prefer a line boundary within the truncated prefix, and
+                    // leave the caller a handle to fetch the rest instead of
+                    // a dead-end ellipsis.
                     let end = prefix.rfind('\n').unwrap_or(prefix.len());
-                    format!("{}...", &prefix[..end])
+                    format!(
+                        "{}\n... [truncated — full body: tokensave_body node_id={}]",
+                        &prefix[..end],
+                        node.id
+                    )
                 } else {
                     code
                 };


### PR DESCRIPTION
# feat(context): point truncated code blocks at tokensave_body

## Summary

- Code blocks truncated at `max_code_block_size` now end with `... [truncated — full body: tokensave_body node_id=<id>]` instead of a bare ellipsis.

## Motivation

A truncated snippet is a dead end for the calling agent: the `...` gives no indication of how to fetch the rest, so the agent either re-derives the symbol by name (an extra search round-trip) or reads the file directly (defeating the token savings). The node id is already on hand in `extract_code_blocks`; embedding it makes the follow-up a single `tokensave_body` call.

## Changes

- `src/context/builder.rs` — `extract_code_blocks` truncation arm appends the handle; the line-boundary preference for the cut point is unchanged.
- `CHANGELOG.md` — entry under `[Unreleased]`.

## Test plan

- [x] `cargo test` passes
- [x] `cargo clippy` has no new warnings (only pre-existing `git.rs:850` `map_or` lint on master)
- [x] Tested manually: `tokensave tool context` on this repo with a long entry point shows the handle, and the emitted `node_id` resolves via `tokensave_body`

## Checklist

- [x] `CHANGELOG.md` updated (under `[Unreleased]` if no version bump)
- [x] No secrets, credentials, or `.env` files included
- [x] Breaking changes documented (if any) — none
