### PR TITLE
fix(search): return real BM25 scores from search_nodes_bounded (#313)

### DIFF
--- a/src/context/builder.rs
+++ b/src/context/builder.rs
@@ -188,10 +188,11 @@ impl<'a> ContextBuilder<'a> {
         symbols: &[String],
         options: &BuildContextOptions,
     ) -> Result<Vec<Node>> {
-        // Base score for an exact name match. Far above any realistic BM25
-        // score (~1e-6 in practice), so a perfect name match always wins the
-        // MAX merge over FTS noise and ranks ahead of it.
-        const EXACT_MATCH_SCORE: f64 = 20.0;
+        // Base score for an exact name match. Negated-BM25 scores from
+        // `search_nodes_bounded` run roughly 5–30 before structural boosts,
+        // so this must sit well above that band for a perfect name match to
+        // win the MAX merge over FTS hits and rank ahead of them.
+        const EXACT_MATCH_SCORE: f64 = 100.0;
         debug_assert!(
             !query.is_empty(),
             "find_entry_points called with empty query"
@@ -261,12 +262,17 @@ impl<'a> ContextBuilder<'a> {
         // "screen") previously consumed the whole pool cap before later, more
         // discriminating terms ("favicon", "oauth") were ever searched
         // (#264). Per-term work stays bounded: each fetch is a ranked
-        // top-`search_limit` query.
+        // top-`fetch_limit` query.
+        // Fetch wider than the BFS-root cap: `search_limit` (default 3) bounds
+        // how many roots seed traversal (#120), but 3 FTS rows per term is too
+        // few for the right symbol to survive merging — a term's top rows are
+        // often file nodes or tests. The root cap below still applies.
+        let fetch_limit = (options.search_limit * 3).max(10);
         let mut per_term: Vec<VecDeque<SearchResult>> = Vec::with_capacity(fts_terms.len());
         for term in &fts_terms {
             per_term.push(
                 self.db
-                    .search_nodes_bounded(term, options.search_limit)
+                    .search_nodes_bounded(term, fetch_limit)
                     .await?
                     .into(),
             );

--- a/src/context/ranking.rs
+++ b/src/context/ranking.rs
@@ -68,6 +68,23 @@ pub fn path_boost(file_path: &str) -> f64 {
     1.0
 }
 
+/// Down-weights test symbols that `path_boost` cannot see: an inline
+/// `#[cfg(test)] mod tests` in `src/*.rs` carries a production file path, so
+/// its `test_*` functions rank as first-party code and can outrank the very
+/// symbol they exercise. Detect them by symbol shape — a `tests`/`test`
+/// module segment in the qualified name, or a `test_` name prefix — and
+/// apply the same 0.4 factor as test files. Soft, like every path factor:
+/// an exact-name match still surfaces via the exact-name supplement.
+pub fn test_symbol_penalty(name: &str, qualified_name: &str) -> f64 {
+    if name.starts_with("test_")
+        || qualified_name.contains("::tests::")
+        || qualified_name.contains("::test::")
+    {
+        return 0.4;
+    }
+    1.0
+}
+
 /// Path segments of generated / vendored / dependency trees that almost
 /// never contain the application code a user is searching for. Matched as
 /// `/segment/` (or as a leading `segment/`) against the `/`-normalized path.
@@ -205,7 +222,8 @@ pub fn rerank_candidates(candidates: &mut [SearchResult]) {
         let boost = kind_boost(&candidate.node.kind)
             * visibility_boost(&candidate.node.visibility)
             * path_boost(&candidate.node.file_path)
-            * path_rank_multiplier(&candidate.node.file_path);
+            * path_rank_multiplier(&candidate.node.file_path)
+            * test_symbol_penalty(&candidate.node.name, &candidate.node.qualified_name);
         candidate.score *= boost;
     }
     candidates.sort_by(|a, b| {
@@ -411,6 +429,36 @@ mod tests {
         assert_eq!(path_boost("tests/sync_test.rs"), 0.4);
         assert_eq!(path_boost("test/fixtures/foo.js"), 0.1);
         assert_eq!(path_boost("src/components/Button.test.tsx"), 0.4);
+    }
+
+    #[test]
+    fn test_symbol_penalty_inline_tests() {
+        // Inline #[cfg(test)] fns carry a production path — penalty comes
+        // from symbol shape instead.
+        assert_eq!(
+            test_symbol_penalty(
+                "test_stem_variants_tion_suffix",
+                "src/context/builder.rs::tests::test_stem_variants_tion_suffix"
+            ),
+            0.4
+        );
+        assert_eq!(
+            test_symbol_penalty("helper", "src/context/builder.rs::tests::helper"),
+            0.4
+        );
+        // The symbol the tests exercise stays untouched.
+        assert_eq!(
+            test_symbol_penalty(
+                "generate_stem_variants",
+                "src/context/builder.rs::generate_stem_variants"
+            ),
+            1.0
+        );
+        // "test" as part of a normal word is not a test module segment.
+        assert_eq!(
+            test_symbol_penalty("attest", "src/attestation.rs::attest"),
+            1.0
+        );
     }
 
     #[test]

--- a/src/db/queries/search.rs
+++ b/src/db/queries/search.rs
@@ -246,8 +246,9 @@ impl Database {
     /// term before `LIMIT` applies. Without the ordering the returned rows are
     /// effectively arbitrary (ascending rowid), which made context building
     /// miss strongly matching symbols for generic terms like "icon" (#264).
-    /// Scores stay flat at `1.0` because context building layers its own
-    /// multi-signal ranking after merging several search channels.
+    /// Scores carry the negated BM25 rank (higher = better), matching
+    /// `search_nodes_fts` — flattening them to `1.0` erased FTS relevance
+    /// before context building's multi-signal reranking ever saw it.
     pub async fn search_nodes_bounded(
         &self,
         query: &str,
@@ -282,11 +283,12 @@ impl Database {
             .query(
                 "SELECT n.id, n.kind, n.name, n.qualified_name, n.file_path,
                     n.start_line, n.end_line, n.start_column, n.end_column,
-                    n.docstring, n.signature, n.visibility, n.is_async, n.branches, n.loops, n.returns, n.max_nesting, n.unsafe_blocks, n.unchecked_calls, n.assertions, n.updated_at, n.attrs_start_line, n.parent_id, n.cognitive_complexity, n.distinct_operators, n.distinct_operands, n.total_operators, n.total_operands
+                    n.docstring, n.signature, n.visibility, n.is_async, n.branches, n.loops, n.returns, n.max_nesting, n.unsafe_blocks, n.unchecked_calls, n.assertions, n.updated_at, n.attrs_start_line, n.parent_id, n.cognitive_complexity, n.distinct_operators, n.distinct_operands, n.total_operators, n.total_operands,
+                    bm25(nodes_fts, 10.0, 5.0, 1.0, 2.0) AS rank
                  FROM nodes_fts
                  JOIN nodes n ON nodes_fts.rowid = n.rowid
                  WHERE nodes_fts MATCH ?1
-                 ORDER BY bm25(nodes_fts, 10.0, 5.0, 1.0, 2.0)
+                 ORDER BY rank
                  LIMIT ?2",
                 params![fts_query, limit as i64],
             )
@@ -305,7 +307,11 @@ impl Database {
                 message: format!("failed to map bounded search result: {e}"),
                 operation: "search_nodes_bounded".to_string(),
             })?;
-            results.push(SearchResult { node, score: 1.0 });
+            let rank: f64 = row.get::<f64>(28).map_err(|e| TokenSaveError::Database {
+                message: format!("failed to read bounded rank: {e}"),
+                operation: "search_nodes_bounded".to_string(),
+            })?;
+            results.push(SearchResult { node, score: -rank });
         }
         Ok(results)
     }

--- a/tests/db_test.rs
+++ b/tests/db_test.rs
@@ -533,3 +533,36 @@ async fn test_migrate_is_idempotent_at_latest() {
         .expect("migrate");
     assert!(!migrated, "second migrate should be a no-op");
 }
+
+#[tokio::test]
+async fn test_search_nodes_bounded_returns_real_descending_scores() {
+    let (db, _dir) = setup_db().await;
+    // One strong match (term in name) and one weak match (term only in docstring).
+    let strong = sample_node("s", "ranking_engine", "src/rank.rs");
+    let mut weak = sample_node("w", "helper", "src/helper.rs");
+    weak.docstring = Some("supports the ranking pipeline".to_string());
+    db.insert_node(&strong).await.expect("insert strong");
+    db.insert_node(&weak).await.expect("insert weak");
+
+    let results = db
+        .search_nodes_bounded("ranking", 10)
+        .await
+        .expect("bounded search");
+    assert!(results.len() >= 2, "expected both rows, got {results:?}");
+    assert!(
+        results.iter().all(|r| r.score > 0.0),
+        "scores must be positive negated-BM25, got {results:?}"
+    );
+    assert!(
+        (results[0].score - results[1].score).abs() > f64::EPSILON,
+        "scores must differentiate name vs docstring matches, got {results:?}"
+    );
+    assert!(
+        results[0].score >= results[1].score,
+        "results must be score-descending"
+    );
+    assert_eq!(
+        results[0].node.id, "s",
+        "name match should outrank docstring"
+    );
+}


### PR DESCRIPTION
Finding 1 + Finding 4 of #313.

## Problem

`search_nodes_bounded_fts` computes `bm25()` to ORDER BY it, then returns `score: 1.0` for every row — while `search_nodes_fts` in the same file returns the negated rank. Context building consumes the bounded variant, so its multiplicative reranking (kind/visibility/path boosts) runs on a flat base and amplifies pool noise instead of FTS relevance. This is the remaining half of #264: the fetch was ranked in 154a28a, but the rank never reaches the reranker.

## Changes

- Return `score = -rank`. Same per-term bounded query — no repo-wide sorting, the value is already computed, zero added query cost.
- `EXACT_MATCH_SCORE` 20 → 100: negated-BM25 runs ~5–30 before boosts; the exact-name floor must clear that band (it was sized for ~1e-6 flat scores).
- Per-term fetch widened to `(search_limit * 3).max(10)`: 3 rows/term is too few for the right symbol to survive merging once row order is meaningful. The BFS-root cap (#120) is unchanged.
- New `test_symbol_penalty` (0.4) in `rerank_candidates`: the wider fetch surfaces inline `#[cfg(test)]` functions, which carry a production path and escape `path_boost`. Detected by symbol shape (`::tests::`/`::test::` qualified-name segment or `test_` prefix); soft, so exact-name matches still surface.

## Verification

- New tests: bounded search returns positive, distinct, descending scores (name match outranks docstring match); `test_symbol_penalty` hits inline test fns, spares production symbols including names merely containing "test".
- Full suite: 2776 passed, 0 failed.
- 12-query eval from #313: hit@3 33% → 58%, MRR .250 → .444, no query regresses.

Note: if the retrieval-diagnostics PR lands first, its "strong" tier threshold should move 1.0 → 10.0 alongside this change (and vice versa — whichever merges second carries the one-line bump).