### PR TITLE
fix(context): exact-name supplement only for symbols the user wrote (#313)

### DIFF
--- a/src/context/builder.rs
+++ b/src/context/builder.rs
@@ -308,9 +308,19 @@ impl<'a> ContextBuilder<'a> {
 
         // --- Exact name supplement ---
         // Ensures perfect name matches aren't buried by BM25 noise.
+        //
+        // Only symbols the user actually wrote qualify: a verbatim query
+        // token ("tokensave_context", "UserService") or a synthesized
+        // multi-word compound ("PromoBanner" from "promo banner", #202).
+        // Single-word segments derived by compound-splitting do NOT — the
+        // split of "tokensave_context" yields "tokensave", which
+        // case-insensitively exact-matches the repo's `TokenSave` god
+        // object, and the API-family supplement then floods the candidate
+        // pool with every one of its methods at exact-tier scores.
         let exact_names: Vec<String> = symbols
             .iter()
             .filter(|s| !s.contains("::") && s.len() >= 3)
+            .filter(|s| is_authored_symbol(s, query, &options.extra_keywords))
             .cloned()
             .collect();
         if !exact_names.is_empty() {
@@ -1080,6 +1090,19 @@ fn classify_token(
     }
 }
 
+/// Returns `true` when `symbol` plausibly came from the user's own words:
+/// a multi-word compound (`PromoBanner`, `process_request`), a verbatim
+/// whitespace-delimited query token (modulo surrounding punctuation), or an
+/// explicitly supplied extra keyword. Single-word segments produced by
+/// compound-splitting fail all three tests and are rejected.
+fn is_authored_symbol(symbol: &str, query: &str, extra_keywords: &[String]) -> bool {
+    split_compound(symbol).len() >= 2
+        || query
+            .split_whitespace()
+            .any(|w| w.trim_matches(|c: char| !c.is_alphanumeric() && c != '_') == symbol)
+        || extra_keywords.iter().any(|k| k == symbol)
+}
+
 /// Split a compound name into individual words.
 ///
 /// Handles camelCase, `PascalCase`, and `snake_case`:
@@ -1410,6 +1433,47 @@ mod tests {
     fn test_extract_snake_case() {
         let symbols = extract_symbols_from_query("fix the process_request function");
         assert!(symbols.contains(&"process_request".to_string()));
+    }
+
+    // --- exact-name provenance ---
+
+    #[test]
+    fn test_authored_symbol_multiword_compound_passes() {
+        // Compounds can only come from the query or synthesis — always eligible.
+        assert!(is_authored_symbol("PromoBanner", "anything", &[]));
+        assert!(is_authored_symbol("process_request", "anything", &[]));
+    }
+
+    #[test]
+    fn test_authored_symbol_verbatim_token_passes() {
+        let q = "how does tokensave_context build its result?";
+        assert!(is_authored_symbol("tokensave_context", q, &[]));
+    }
+
+    #[test]
+    fn test_authored_symbol_trims_punctuation() {
+        assert!(is_authored_symbol(
+            "tokensave_context",
+            "call tokensave_context.",
+            &[]
+        ));
+    }
+
+    #[test]
+    fn test_authored_symbol_derived_segment_rejected() {
+        // "tokensave" is a split segment of "tokensave_context", not a word
+        // the user wrote — it must not qualify for exact-name matching.
+        let q = "how does tokensave_context build its result?";
+        assert!(!is_authored_symbol("tokensave", q, &[]));
+    }
+
+    #[test]
+    fn test_authored_symbol_extra_keyword_passes() {
+        assert!(is_authored_symbol(
+            "ranker",
+            "unrelated query",
+            &["ranker".to_string()]
+        ));
     }
 
     #[test]

--- a/src/context/builder.rs
+++ b/src/context/builder.rs
@@ -188,10 +188,11 @@ impl<'a> ContextBuilder<'a> {
         symbols: &[String],
         options: &BuildContextOptions,
     ) -> Result<Vec<Node>> {
-        // Base score for an exact name match. Far above any realistic BM25
-        // score (~1e-6 in practice), so a perfect name match always wins the
-        // MAX merge over FTS noise and ranks ahead of it.
-        const EXACT_MATCH_SCORE: f64 = 20.0;
+        // Base score for an exact name match. Negated-BM25 scores from
+        // `search_nodes_bounded` run roughly 5–30 before structural boosts,
+        // so this must sit well above that band for a perfect name match to
+        // win the MAX merge over FTS hits and rank ahead of them.
+        const EXACT_MATCH_SCORE: f64 = 100.0;
         debug_assert!(
             !query.is_empty(),
             "find_entry_points called with empty query"
@@ -261,12 +262,17 @@ impl<'a> ContextBuilder<'a> {
         // "screen") previously consumed the whole pool cap before later, more
         // discriminating terms ("favicon", "oauth") were ever searched
         // (#264). Per-term work stays bounded: each fetch is a ranked
-        // top-`search_limit` query.
+        // top-`fetch_limit` query.
+        // Fetch wider than the BFS-root cap: `search_limit` (default 3) bounds
+        // how many roots seed traversal (#120), but 3 FTS rows per term is too
+        // few for the right symbol to survive merging — a term's top rows are
+        // often file nodes or tests. The root cap below still applies.
+        let fetch_limit = (options.search_limit * 3).max(10);
         let mut per_term: Vec<VecDeque<SearchResult>> = Vec::with_capacity(fts_terms.len());
         for term in &fts_terms {
             per_term.push(
                 self.db
-                    .search_nodes_bounded(term, options.search_limit)
+                    .search_nodes_bounded(term, fetch_limit)
                     .await?
                     .into(),
             );

--- a/src/context/ranking.rs
+++ b/src/context/ranking.rs
@@ -68,6 +68,23 @@ pub fn path_boost(file_path: &str) -> f64 {
     1.0
 }
 
+/// Down-weights test symbols that `path_boost` cannot see: an inline
+/// `#[cfg(test)] mod tests` in `src/*.rs` carries a production file path, so
+/// its `test_*` functions rank as first-party code and can outrank the very
+/// symbol they exercise. Detect them by symbol shape — a `tests`/`test`
+/// module segment in the qualified name, or a `test_` name prefix — and
+/// apply the same 0.4 factor as test files. Soft, like every path factor:
+/// an exact-name match still surfaces via the exact-name supplement.
+pub fn test_symbol_penalty(name: &str, qualified_name: &str) -> f64 {
+    if name.starts_with("test_")
+        || qualified_name.contains("::tests::")
+        || qualified_name.contains("::test::")
+    {
+        return 0.4;
+    }
+    1.0
+}
+
 /// Path segments of generated / vendored / dependency trees that almost
 /// never contain the application code a user is searching for. Matched as
 /// `/segment/` (or as a leading `segment/`) against the `/`-normalized path.
@@ -205,7 +222,8 @@ pub fn rerank_candidates(candidates: &mut [SearchResult]) {
         let boost = kind_boost(&candidate.node.kind)
             * visibility_boost(&candidate.node.visibility)
             * path_boost(&candidate.node.file_path)
-            * path_rank_multiplier(&candidate.node.file_path);
+            * path_rank_multiplier(&candidate.node.file_path)
+            * test_symbol_penalty(&candidate.node.name, &candidate.node.qualified_name);
         candidate.score *= boost;
     }
     candidates.sort_by(|a, b| {
@@ -411,6 +429,36 @@ mod tests {
         assert_eq!(path_boost("tests/sync_test.rs"), 0.4);
         assert_eq!(path_boost("test/fixtures/foo.js"), 0.1);
         assert_eq!(path_boost("src/components/Button.test.tsx"), 0.4);
+    }
+
+    #[test]
+    fn test_symbol_penalty_inline_tests() {
+        // Inline #[cfg(test)] fns carry a production path — penalty comes
+        // from symbol shape instead.
+        assert_eq!(
+            test_symbol_penalty(
+                "test_stem_variants_tion_suffix",
+                "src/context/builder.rs::tests::test_stem_variants_tion_suffix"
+            ),
+            0.4
+        );
+        assert_eq!(
+            test_symbol_penalty("helper", "src/context/builder.rs::tests::helper"),
+            0.4
+        );
+        // The symbol the tests exercise stays untouched.
+        assert_eq!(
+            test_symbol_penalty(
+                "generate_stem_variants",
+                "src/context/builder.rs::generate_stem_variants"
+            ),
+            1.0
+        );
+        // "test" as part of a normal word is not a test module segment.
+        assert_eq!(
+            test_symbol_penalty("attest", "src/attestation.rs::attest"),
+            1.0
+        );
     }
 
     #[test]

--- a/src/db/queries/search.rs
+++ b/src/db/queries/search.rs
@@ -246,8 +246,9 @@ impl Database {
     /// term before `LIMIT` applies. Without the ordering the returned rows are
     /// effectively arbitrary (ascending rowid), which made context building
     /// miss strongly matching symbols for generic terms like "icon" (#264).
-    /// Scores stay flat at `1.0` because context building layers its own
-    /// multi-signal ranking after merging several search channels.
+    /// Scores carry the negated BM25 rank (higher = better), matching
+    /// `search_nodes_fts` — flattening them to `1.0` erased FTS relevance
+    /// before context building's multi-signal reranking ever saw it.
     pub async fn search_nodes_bounded(
         &self,
         query: &str,
@@ -282,11 +283,12 @@ impl Database {
             .query(
                 "SELECT n.id, n.kind, n.name, n.qualified_name, n.file_path,
                     n.start_line, n.end_line, n.start_column, n.end_column,
-                    n.docstring, n.signature, n.visibility, n.is_async, n.branches, n.loops, n.returns, n.max_nesting, n.unsafe_blocks, n.unchecked_calls, n.assertions, n.updated_at, n.attrs_start_line, n.parent_id, n.cognitive_complexity, n.distinct_operators, n.distinct_operands, n.total_operators, n.total_operands
+                    n.docstring, n.signature, n.visibility, n.is_async, n.branches, n.loops, n.returns, n.max_nesting, n.unsafe_blocks, n.unchecked_calls, n.assertions, n.updated_at, n.attrs_start_line, n.parent_id, n.cognitive_complexity, n.distinct_operators, n.distinct_operands, n.total_operators, n.total_operands,
+                    bm25(nodes_fts, 10.0, 5.0, 1.0, 2.0) AS rank
                  FROM nodes_fts
                  JOIN nodes n ON nodes_fts.rowid = n.rowid
                  WHERE nodes_fts MATCH ?1
-                 ORDER BY bm25(nodes_fts, 10.0, 5.0, 1.0, 2.0)
+                 ORDER BY rank
                  LIMIT ?2",
                 params![fts_query, limit as i64],
             )
@@ -305,7 +307,11 @@ impl Database {
                 message: format!("failed to map bounded search result: {e}"),
                 operation: "search_nodes_bounded".to_string(),
             })?;
-            results.push(SearchResult { node, score: 1.0 });
+            let rank: f64 = row.get::<f64>(28).map_err(|e| TokenSaveError::Database {
+                message: format!("failed to read bounded rank: {e}"),
+                operation: "search_nodes_bounded".to_string(),
+            })?;
+            results.push(SearchResult { node, score: -rank });
         }
         Ok(results)
     }

--- a/tests/db_test.rs
+++ b/tests/db_test.rs
@@ -533,3 +533,36 @@ async fn test_migrate_is_idempotent_at_latest() {
         .expect("migrate");
     assert!(!migrated, "second migrate should be a no-op");
 }
+
+#[tokio::test]
+async fn test_search_nodes_bounded_returns_real_descending_scores() {
+    let (db, _dir) = setup_db().await;
+    // One strong match (term in name) and one weak match (term only in docstring).
+    let strong = sample_node("s", "ranking_engine", "src/rank.rs");
+    let mut weak = sample_node("w", "helper", "src/helper.rs");
+    weak.docstring = Some("supports the ranking pipeline".to_string());
+    db.insert_node(&strong).await.expect("insert strong");
+    db.insert_node(&weak).await.expect("insert weak");
+
+    let results = db
+        .search_nodes_bounded("ranking", 10)
+        .await
+        .expect("bounded search");
+    assert!(results.len() >= 2, "expected both rows, got {results:?}");
+    assert!(
+        results.iter().all(|r| r.score > 0.0),
+        "scores must be positive negated-BM25, got {results:?}"
+    );
+    assert!(
+        (results[0].score - results[1].score).abs() > f64::EPSILON,
+        "scores must differentiate name vs docstring matches, got {results:?}"
+    );
+    assert!(
+        results[0].score >= results[1].score,
+        "results must be score-descending"
+    );
+    assert_eq!(
+        results[0].node.id, "s",
+        "name match should outrank docstring"
+    );
+}


### PR DESCRIPTION
Finding 2 of #313. Stacked on #314 (first commit here is #314; review the second).

## Problem

The exact-name supplement consumes every extracted symbol, including single-word segments produced by compound splitting — words the user never typed. Splitting `tokensave_context` yields `tokensave`, which case-insensitively exact-matches this repo's `TokenSave` struct; the API-family supplement then floods the candidate pool with its methods at exact-tier scores. Repro: `tokensave tool context --task "How does tokensave_context build its result: candidate selection, ranking, token budgeting, snippet truncation"` returns `TokenSave`-adjacent entry points instead of `find_entry_points`/`rerank_candidates`/`build_context`.

## Change

Gate the supplement on provenance via `is_authored_symbol`: a symbol qualifies only if it is a multi-word compound (the #202 synthesis path, preserved), appears verbatim as a whitespace-delimited query token (modulo surrounding punctuation), or was passed in `extra_keywords`. Derived single-word segments fall back to ranked FTS — ranked, not anointed. The #117 MAX-merge behavior is untouched.

## Verification

- 5 unit tests on the predicate (compound passes, verbatim passes, punctuation trimmed, derived segment rejected, extra keyword passes).
- Full suite: 2780 passed, 0 failed.
- The repro above flips to rank 1. 12-query eval from #313: hit@3 58% → 66%, MRR .444 → .528, no query regresses.
