### PR TITLE
feat(db): porter stemming + index-time camelCase terms, schema v14 (#313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project uses [maintenance-based versioning](TOKENSAVE-VERSIONING.md), n
 
 ## [Unreleased]
 
+### Changed
+- **Symbol FTS now stems at the index (`porter unicode61`), and camelCase inner words are indexed at insert time (schema v14).** Inflected prose in a `tokensave_context` task — "candidates", "truncation", "generates" — previously matched nothing, because the unicode61 tokenizer is exact-token and the identifiers are `candidate`/`truncate`/`generate` (#264 called out the missing `generates` → `generate` normalization). The porter tokenizer makes that class of match work for any suffix at query time instead of patching common cases query-side. A new `search_terms` column carries the words a tokenizer cannot derive on its own — the inner words of a camelCase identifier (`updateCloudClient` → `Cloud Client`), computed once at insert by `text::search_terms` and weighted between `qualified_name` and `name` in `bm25()`; it stays empty for snake_case names, which unicode61 already splits on `_`, so the column adds nothing for codebases like this one and closes the #202 class (spaced natural-language query vs. camelCase TSX symbol) for the TS/Java/Go side of the language table. Migration v14 adds the column, backfills it, and rebuilds `nodes_fts` with the new tokenizer — all derived data, so the worst case is a re-index; nothing user-authored is touched.
+
+### Removed
+- **Both query-side stemming workarounds are deleted, subsumed by the porter tokenizer.** The trailing-`s` strip from #264 and `generate_stem_variants`' hand-rolled suffix table existed only because the index didn't stem. Porter covers every conflation the suffix table targeted — verified directly against FTS5 (authentication ↔ authenticator ↔ authenticate, configuration ↔ configure, serializer ↔ serialization, truncation ↔ truncate, validator ↔ validated); the one jump neither makes is resolution → resolve, so nothing is lost. On a 12-query retrieval eval the entry points are identical with the workarounds removed.
+
 
 ## [7.8.1] - 2026-07-27
 

--- a/src/context/builder.rs
+++ b/src/context/builder.rs
@@ -9,6 +9,7 @@ use crate::context::ranking::{
 use crate::db::Database;
 use crate::errors::Result;
 use crate::graph::GraphTraverser;
+use crate::text::{is_camel_case, split_compound};
 use crate::types::*;
 
 /// Builds AI-ready context by combining search, graph traversal, and source code extraction.
@@ -170,8 +171,9 @@ impl<'a> ContextBuilder<'a> {
     /// Searches for entry-point nodes matching the query and extracted symbols.
     ///
     /// Pipeline:
-    /// 1. FTS search on the full query, each extracted symbol, stem variants,
-    ///    and agent-provided extra keywords.
+    /// 1. FTS search on the full query, each extracted symbol, and
+    ///    agent-provided extra keywords (the porter tokenizer handles
+    ///    inflected variants at match time).
     /// 2. Exact name supplement — ensures perfect name matches are never buried
     ///    by BM25 noise.
     /// 3. Exact source supplement — qualified expressions such as
@@ -234,22 +236,12 @@ impl<'a> ContextBuilder<'a> {
         };
         let body_terms = conceptual_query_terms(query, &options.extra_keywords);
         for term in &body_terms {
+            // The symbol FTS index uses `porter unicode61`, so inflected prose
+            // ("generates", "ranking") stems to match indexed identifiers —
+            // the old query-side plural-strip hack (#264) is no longer needed.
             push_term(term.clone(), &mut fts_terms, &mut fts_seen);
-            // The symbol FTS tokenizer (unicode61) does not stem, so a prose
-            // verb like "generates" never prefix-matches an indexed name such
-            // as `generateLauncherIcon`. Fold a trailing plural/third-person
-            // `s` into a second search term (#264).
-            if let Some(stem) = term.strip_suffix('s') {
-                if stem.len() >= 4 && !stem.ends_with('s') {
-                    push_term(stem.to_string(), &mut fts_terms, &mut fts_seen);
-                }
-            }
         }
         for s in symbols {
-            push_term(s.clone(), &mut fts_terms, &mut fts_seen);
-        }
-        let stems = generate_stem_variants(symbols);
-        for s in &stems {
             push_term(s.clone(), &mut fts_terms, &mut fts_seen);
         }
         for k in &options.extra_keywords {
@@ -1103,119 +1095,6 @@ fn is_authored_symbol(symbol: &str, query: &str, extra_keywords: &[String]) -> b
         || extra_keywords.iter().any(|k| k == symbol)
 }
 
-/// Split a compound name into individual words.
-///
-/// Handles camelCase, `PascalCase`, and `snake_case`:
-/// - `getUserName` → `["get", "User", "Name"]`
-/// - `process_request` → `["process", "request"]`
-/// - `MAX_RETRIES` → `["MAX", "RETRIES"]`
-fn split_compound(name: &str) -> Vec<&str> {
-    if name.contains('_') {
-        return name.split('_').filter(|s| !s.is_empty()).collect();
-    }
-
-    // camelCase / PascalCase splitting
-    let bytes = name.as_bytes();
-    let mut parts = Vec::new();
-    let mut start = 0;
-
-    for i in 1..bytes.len() {
-        let cur = bytes[i] as char;
-        let prev = bytes[i - 1] as char;
-
-        // Split at lowercase→uppercase boundary (e.g. getUser → get|User)
-        let boundary = prev.is_ascii_lowercase() && cur.is_ascii_uppercase();
-        // Split at uppercase→uppercase+lowercase (e.g. XMLParser → XML|Parser)
-        let acronym_end = i + 1 < bytes.len()
-            && prev.is_ascii_uppercase()
-            && cur.is_ascii_uppercase()
-            && (bytes[i + 1] as char).is_ascii_lowercase();
-
-        if boundary || acronym_end {
-            if i > start {
-                parts.push(&name[start..i]);
-            }
-            start = i;
-        }
-    }
-    if start < name.len() {
-        parts.push(&name[start..]);
-    }
-    parts
-}
-
-/// Returns `true` if `word` looks like CamelCase.
-///
-/// The word must contain at least one uppercase letter after the first character
-/// and consist only of ASCII alphanumeric characters.
-fn is_camel_case(word: &str) -> bool {
-    if word.len() < 2 {
-        return false;
-    }
-    // Must be all alphanumeric
-    if !word.chars().all(|c| c.is_ascii_alphanumeric()) {
-        return false;
-    }
-    // Must have at least one uppercase letter after the first char
-    word[1..].chars().any(|c| c.is_ascii_uppercase())
-}
-
-/// Generates suffix-based stem variants for a set of symbols.
-///
-/// For each symbol, tries common suffixes (e.g. "authenticate" generates
-/// "authentication", "authenticator", "authenticated"). Only produces
-/// variants that differ from the original and from other symbols.
-fn generate_stem_variants(symbols: &[String]) -> Vec<String> {
-    /// Common English derivational suffixes, ordered longest-first so that
-    /// stripping "ation" is preferred over "ion" when both match.
-    const SUFFIX_PAIRS: &[(&str, &[&str])] = &[
-        ("tion", &["te", "tor", "t", "ting"]),
-        ("sion", &["de", "d", "ding"]),
-        ("ment", &["", "ing", "ed"]),
-        ("ness", &["", "ly"]),
-        ("ing", &["", "e", "ion", "ment"]),
-        ("ed", &["", "e", "ing", "ion"]),
-        ("er", &["", "e", "ing", "ed"]),
-        ("or", &["", "e", "ion"]),
-        ("ly", &["", "ness"]),
-        ("ize", &["ization", "ized"]),
-        ("ise", &["isation", "ised"]),
-        ("ate", &["ation", "ator", "ated", "ating"]),
-        ("ify", &["ification", "ified"]),
-    ];
-
-    let existing: HashSet<String> = symbols.iter().map(|s| s.to_lowercase()).collect();
-    let mut variants: Vec<String> = Vec::new();
-    let mut seen: HashSet<String> = HashSet::new();
-
-    for symbol in symbols {
-        let lower = symbol.to_lowercase();
-        if lower.len() < 4 {
-            continue;
-        }
-
-        for &(suffix, replacements) in SUFFIX_PAIRS {
-            if let Some(stem) = lower.strip_suffix(suffix) {
-                if stem.len() < 2 {
-                    continue;
-                }
-                for &replacement in replacements {
-                    let variant = format!("{stem}{replacement}");
-                    if variant.len() >= 3
-                        && !existing.contains(&variant)
-                        && seen.insert(variant.clone())
-                    {
-                        variants.push(variant);
-                    }
-                }
-                break; // only strip the first matching suffix
-            }
-        }
-    }
-
-    variants
-}
-
 /// Extracts exact, namespace-qualified source tokens from the task and extra
 /// keywords. Surrounding prose punctuation and Markdown backticks are removed,
 /// but the original case is retained for case-sensitive literal matching.
@@ -1516,57 +1395,6 @@ mod tests {
     fn test_filters_stop_words() {
         let symbols = extract_symbols_from_query("the is in for to a an");
         assert!(symbols.is_empty());
-    }
-
-    #[test]
-    fn test_is_camel_case() {
-        assert!(is_camel_case("UserService"));
-        assert!(is_camel_case("processRequest"));
-        assert!(!is_camel_case("user"));
-        assert!(!is_camel_case("U"));
-        assert!(!is_camel_case("process_request"));
-    }
-
-    // --- stem variant tests ---
-
-    #[test]
-    fn test_stem_variants_ate_suffix() {
-        let symbols = vec!["authenticate".to_string()];
-        let variants = generate_stem_variants(&symbols);
-        assert!(variants.contains(&"authentication".to_string()));
-        assert!(variants.contains(&"authenticator".to_string()));
-    }
-
-    #[test]
-    fn test_stem_variants_tion_suffix() {
-        let symbols = vec!["authentication".to_string()];
-        let variants = generate_stem_variants(&symbols);
-        assert!(variants.contains(&"authenticate".to_string()));
-    }
-
-    #[test]
-    fn test_stem_variants_ing_suffix() {
-        let symbols = vec!["parsing".to_string()];
-        let variants = generate_stem_variants(&symbols);
-        // "parsing" → strip "ing" → stem "pars" → ["pars", "parse", "parsion", "parsment"]
-        assert!(variants.contains(&"parse".to_string()));
-    }
-
-    #[test]
-    fn test_stem_variants_short_words_skipped() {
-        let symbols = vec!["ab".to_string()];
-        let variants = generate_stem_variants(&symbols);
-        assert!(variants.is_empty());
-    }
-
-    #[test]
-    fn test_stem_variants_no_duplicates_with_existing() {
-        let symbols = vec!["authenticate".to_string(), "authentication".to_string()];
-        let variants = generate_stem_variants(&symbols);
-        // "authentication" is already in symbols, so it shouldn't appear in variants
-        assert!(!variants.contains(&"authentication".to_string()));
-        // "authenticate" is already in symbols, so it shouldn't appear in variants
-        assert!(!variants.contains(&"authenticate".to_string()));
     }
 
     // --- co-occurrence boost tests ---

--- a/src/db/migrations.rs
+++ b/src/db/migrations.rs
@@ -9,13 +9,13 @@
 //! The current schema version is stored in `PRAGMA user_version`, which
 //! is an atomic integer built into `SQLite`. No extra table is needed.
 
-use libsql::Connection;
+use libsql::{params, Connection};
 
 use crate::errors::{Result, TokenSaveError};
 
 /// The highest migration version defined in this file. Bump this and add a
 /// new entry to `run_migration` whenever the schema changes.
-const LATEST_VERSION: u32 = 13;
+const LATEST_VERSION: u32 = 14;
 
 pub(crate) const TRAIT_DISPATCH_TRIGGERS_SQL: &str = r"
 CREATE TRIGGER IF NOT EXISTS trait_dispatch_call_insert
@@ -153,7 +153,8 @@ pub async fn create_schema(conn: &Connection) -> Result<()> {
             distinct_operators INTEGER NOT NULL DEFAULT 0,
             distinct_operands INTEGER NOT NULL DEFAULT 0,
             total_operators INTEGER NOT NULL DEFAULT 0,
-            total_operands INTEGER NOT NULL DEFAULT 0
+            total_operands INTEGER NOT NULL DEFAULT 0,
+            search_terms TEXT NOT NULL DEFAULT ''
         );
 
         CREATE TABLE IF NOT EXISTS edges (
@@ -200,8 +201,9 @@ pub async fn create_schema(conn: &Connection) -> Result<()> {
         );
 
         CREATE VIRTUAL TABLE IF NOT EXISTS nodes_fts USING fts5(
-            name, qualified_name, docstring, signature,
-            content='nodes', content_rowid='rowid'
+            name, qualified_name, docstring, signature, search_terms,
+            content='nodes', content_rowid='rowid',
+            tokenize='porter unicode61'
         );
 
         CREATE VIRTUAL TABLE IF NOT EXISTS executable_body_fts USING fts5(
@@ -223,20 +225,20 @@ pub async fn create_schema(conn: &Connection) -> Result<()> {
             ON trait_dispatch_callers(concrete_method_id);
 
         CREATE TRIGGER IF NOT EXISTS nodes_fts_insert AFTER INSERT ON nodes BEGIN
-            INSERT INTO nodes_fts(rowid, name, qualified_name, docstring, signature)
-            VALUES (NEW.rowid, NEW.name, NEW.qualified_name, NEW.docstring, NEW.signature);
+            INSERT INTO nodes_fts(rowid, name, qualified_name, docstring, signature, search_terms)
+            VALUES (NEW.rowid, NEW.name, NEW.qualified_name, NEW.docstring, NEW.signature, NEW.search_terms);
         END;
 
         CREATE TRIGGER IF NOT EXISTS nodes_fts_delete AFTER DELETE ON nodes BEGIN
-            INSERT INTO nodes_fts(nodes_fts, rowid, name, qualified_name, docstring, signature)
-            VALUES ('delete', OLD.rowid, OLD.name, OLD.qualified_name, OLD.docstring, OLD.signature);
+            INSERT INTO nodes_fts(nodes_fts, rowid, name, qualified_name, docstring, signature, search_terms)
+            VALUES ('delete', OLD.rowid, OLD.name, OLD.qualified_name, OLD.docstring, OLD.signature, OLD.search_terms);
         END;
 
         CREATE TRIGGER IF NOT EXISTS nodes_fts_update AFTER UPDATE ON nodes BEGIN
-            INSERT INTO nodes_fts(nodes_fts, rowid, name, qualified_name, docstring, signature)
-            VALUES ('delete', OLD.rowid, OLD.name, OLD.qualified_name, OLD.docstring, OLD.signature);
-            INSERT INTO nodes_fts(rowid, name, qualified_name, docstring, signature)
-            VALUES (NEW.rowid, NEW.name, NEW.qualified_name, NEW.docstring, NEW.signature);
+            INSERT INTO nodes_fts(nodes_fts, rowid, name, qualified_name, docstring, signature, search_terms)
+            VALUES ('delete', OLD.rowid, OLD.name, OLD.qualified_name, OLD.docstring, OLD.signature, OLD.search_terms);
+            INSERT INTO nodes_fts(rowid, name, qualified_name, docstring, signature, search_terms)
+            VALUES (NEW.rowid, NEW.name, NEW.qualified_name, NEW.docstring, NEW.signature, NEW.search_terms);
         END;
 
         CREATE INDEX IF NOT EXISTS idx_nodes_kind ON nodes(kind);
@@ -431,6 +433,7 @@ async fn run_migration(conn: &Connection, version: u32) -> Result<()> {
         11 => migrate_v11(conn).await,
         12 => migrate_v12(conn).await,
         13 => migrate_v13(conn).await,
+        14 => migrate_v14(conn).await,
         _ => Err(TokenSaveError::Database {
             message: format!("unknown migration version: {version}"),
             operation: "run_migration".to_string(),
@@ -1130,6 +1133,118 @@ async fn migrate_v13(conn: &Connection) -> Result<()> {
                 operation: "migrate_v13".to_string(),
             })?;
     }
+    Ok(())
+}
+
+/// v14: retrieval graft from codebase-memory — adds the `search_terms`
+/// column (camelCase word segments computed at write time), rebuilds
+/// `nodes_fts` with that column and the `porter unicode61` tokenizer so
+/// inflected prose queries ("ranking", "candidates") match indexed
+/// identifiers, and backfills existing rows.
+async fn migrate_v14(conn: &Connection) -> Result<()> {
+    let cols = node_columns(conn).await?;
+    if !cols.iter().any(|c| c == "search_terms") {
+        conn.execute_batch("ALTER TABLE nodes ADD COLUMN search_terms TEXT NOT NULL DEFAULT ''")
+            .await
+            .map_err(|e| TokenSaveError::Database {
+                message: format!("v14: failed to add search_terms column: {e}"),
+                operation: "migrate_v14".to_string(),
+            })?;
+    }
+
+    // Drop the old FTS table and its triggers before the backfill so the
+    // UPDATEs below don't fire FTS sync triggers against a table that is
+    // about to be rebuilt anyway.
+    conn.execute_batch(
+        "DROP TRIGGER IF EXISTS nodes_fts_insert;
+         DROP TRIGGER IF EXISTS nodes_fts_delete;
+         DROP TRIGGER IF EXISTS nodes_fts_update;
+         DROP TABLE IF EXISTS nodes_fts;",
+    )
+    .await
+    .map_err(|e| TokenSaveError::Database {
+        message: format!("v14: failed to drop old FTS table: {e}"),
+        operation: "migrate_v14".to_string(),
+    })?;
+
+    // Backfill search_terms for existing nodes. Only rows that actually have
+    // camelCase-derived segments need a write; snake_case names produce an
+    // empty string, which the column already defaults to.
+    let mut rows = conn
+        .query("SELECT rowid, name, qualified_name FROM nodes", ())
+        .await
+        .map_err(|e| TokenSaveError::Database {
+            message: format!("v14: failed to read nodes for backfill: {e}"),
+            operation: "migrate_v14".to_string(),
+        })?;
+    let mut backfill: Vec<(i64, String)> = Vec::new();
+    while let Some(row) = rows.next().await.map_err(|e| TokenSaveError::Database {
+        message: format!("v14: failed to read backfill row: {e}"),
+        operation: "migrate_v14".to_string(),
+    })? {
+        let rowid: i64 = row.get(0).map_err(|e| TokenSaveError::Database {
+            message: format!("v14: failed to read rowid: {e}"),
+            operation: "migrate_v14".to_string(),
+        })?;
+        let name: String = row.get(1).map_err(|e| TokenSaveError::Database {
+            message: format!("v14: failed to read name: {e}"),
+            operation: "migrate_v14".to_string(),
+        })?;
+        let qualified_name: String = row.get(2).map_err(|e| TokenSaveError::Database {
+            message: format!("v14: failed to read qualified_name: {e}"),
+            operation: "migrate_v14".to_string(),
+        })?;
+        let terms = crate::text::search_terms(&name, &qualified_name);
+        if !terms.is_empty() {
+            backfill.push((rowid, terms));
+        }
+    }
+    drop(rows);
+    for (rowid, terms) in backfill {
+        conn.execute(
+            "UPDATE nodes SET search_terms = ?1 WHERE rowid = ?2",
+            params![terms, rowid],
+        )
+        .await
+        .map_err(|e| TokenSaveError::Database {
+            message: format!("v14: failed to backfill search_terms: {e}"),
+            operation: "migrate_v14".to_string(),
+        })?;
+    }
+
+    // Recreate the FTS table with the new column + porter stemming, its sync
+    // triggers, and rebuild the index from the content table.
+    conn.execute_batch(
+        "CREATE VIRTUAL TABLE nodes_fts USING fts5(
+            name, qualified_name, docstring, signature, search_terms,
+            content='nodes', content_rowid='rowid',
+            tokenize='porter unicode61'
+        );
+
+        CREATE TRIGGER nodes_fts_insert AFTER INSERT ON nodes BEGIN
+            INSERT INTO nodes_fts(rowid, name, qualified_name, docstring, signature, search_terms)
+            VALUES (NEW.rowid, NEW.name, NEW.qualified_name, NEW.docstring, NEW.signature, NEW.search_terms);
+        END;
+
+        CREATE TRIGGER nodes_fts_delete AFTER DELETE ON nodes BEGIN
+            INSERT INTO nodes_fts(nodes_fts, rowid, name, qualified_name, docstring, signature, search_terms)
+            VALUES ('delete', OLD.rowid, OLD.name, OLD.qualified_name, OLD.docstring, OLD.signature, OLD.search_terms);
+        END;
+
+        CREATE TRIGGER nodes_fts_update AFTER UPDATE ON nodes BEGIN
+            INSERT INTO nodes_fts(nodes_fts, rowid, name, qualified_name, docstring, signature, search_terms)
+            VALUES ('delete', OLD.rowid, OLD.name, OLD.qualified_name, OLD.docstring, OLD.signature, OLD.search_terms);
+            INSERT INTO nodes_fts(rowid, name, qualified_name, docstring, signature, search_terms)
+            VALUES (NEW.rowid, NEW.name, NEW.qualified_name, NEW.docstring, NEW.signature, NEW.search_terms);
+        END;
+
+        INSERT INTO nodes_fts(nodes_fts) VALUES('rebuild');",
+    )
+    .await
+    .map_err(|e| TokenSaveError::Database {
+        message: format!("v14: failed to recreate FTS table: {e}"),
+        operation: "migrate_v14".to_string(),
+    })?;
     Ok(())
 }
 

--- a/src/db/queries/nodes.rs
+++ b/src/db/queries/nodes.rs
@@ -15,8 +15,8 @@ impl Database {
                  start_line, end_line, start_column, end_column,
                  docstring, signature, visibility, is_async,
                  branches, loops, returns, max_nesting,
-                 unsafe_blocks, unchecked_calls, assertions, updated_at, attrs_start_line, parent_id, cognitive_complexity, distinct_operators, distinct_operands, total_operators, total_operands)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28)",
+                 unsafe_blocks, unchecked_calls, assertions, updated_at, attrs_start_line, parent_id, cognitive_complexity, distinct_operators, distinct_operands, total_operators, total_operands, search_terms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29)",
                 params![
                     node.id.as_str(),
                     node.kind.as_str(),
@@ -46,6 +46,7 @@ impl Database {
                     i64::from(node.distinct_operands),
                     i64::from(node.total_operators),
                     i64::from(node.total_operands),
+                    crate::text::search_terms(&node.name, &node.qualified_name),
                 ],
             )
             .await
@@ -119,7 +120,7 @@ impl Database {
                  start_line,end_line,start_column,end_column,\
                  docstring,signature,visibility,is_async,\
                  branches,loops,returns,max_nesting,\
-                 unsafe_blocks,unchecked_calls,assertions,updated_at,attrs_start_line,parent_id,cognitive_complexity,distinct_operators,distinct_operands,total_operators,total_operands) VALUES ",
+                 unsafe_blocks,unchecked_calls,assertions,updated_at,attrs_start_line,parent_id,cognitive_complexity,distinct_operators,distinct_operands,total_operators,total_operands,search_terms) VALUES ",
             );
             for (i, node) in chunk.iter().enumerate() {
                 if i > 0 {
@@ -181,6 +182,11 @@ impl Database {
                 push_int(&mut sql, i64::from(node.total_operators));
                 sql.push(',');
                 push_int(&mut sql, i64::from(node.total_operands));
+                sql.push(',');
+                push_quoted(
+                    &mut sql,
+                    &crate::text::search_terms(&node.name, &node.qualified_name),
+                );
                 sql.push(')');
             }
             sql.push_str(";\n");
@@ -270,8 +276,8 @@ impl Database {
                  start_line,end_line,start_column,end_column,\
                  docstring,signature,visibility,is_async,\
                  branches,loops,returns,max_nesting,\
-                 unsafe_blocks,unchecked_calls,assertions,updated_at,attrs_start_line,parent_id,cognitive_complexity,distinct_operators,distinct_operands,total_operators,total_operands) \
-                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,?25,?26,?27,?28)"
+                 unsafe_blocks,unchecked_calls,assertions,updated_at,attrs_start_line,parent_id,cognitive_complexity,distinct_operators,distinct_operands,total_operators,total_operands,search_terms) \
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,?25,?26,?27,?28,?29)"
             )
             .await
             .map_err(|e| TokenSaveError::Database {
@@ -309,6 +315,7 @@ impl Database {
                 i64::from(node.distinct_operands),
                 i64::from(node.total_operators),
                 i64::from(node.total_operands),
+                crate::text::search_terms(&node.name, &node.qualified_name),
             ])
             .await
             .map_err(|e| TokenSaveError::Database {

--- a/src/db/queries/search.rs
+++ b/src/db/queries/search.rs
@@ -284,7 +284,7 @@ impl Database {
                 "SELECT n.id, n.kind, n.name, n.qualified_name, n.file_path,
                     n.start_line, n.end_line, n.start_column, n.end_column,
                     n.docstring, n.signature, n.visibility, n.is_async, n.branches, n.loops, n.returns, n.max_nesting, n.unsafe_blocks, n.unchecked_calls, n.assertions, n.updated_at, n.attrs_start_line, n.parent_id, n.cognitive_complexity, n.distinct_operators, n.distinct_operands, n.total_operators, n.total_operands,
-                    bm25(nodes_fts, 10.0, 5.0, 1.0, 2.0) AS rank
+                    bm25(nodes_fts, 10.0, 5.0, 1.0, 2.0, 6.0) AS rank
                  FROM nodes_fts
                  JOIN nodes n ON nodes_fts.rowid = n.rowid
                  WHERE nodes_fts MATCH ?1
@@ -328,11 +328,11 @@ impl Database {
                 "SELECT n.id, n.kind, n.name, n.qualified_name, n.file_path,
                     n.start_line, n.end_line, n.start_column, n.end_column,
                     n.docstring, n.signature, n.visibility, n.is_async, n.branches, n.loops, n.returns, n.max_nesting, n.unsafe_blocks, n.unchecked_calls, n.assertions, n.updated_at, n.attrs_start_line, n.parent_id, n.cognitive_complexity, n.distinct_operators, n.distinct_operands, n.total_operators, n.total_operands,
-                    bm25(nodes_fts, 10.0, 5.0, 1.0, 2.0) AS rank
+                    bm25(nodes_fts, 10.0, 5.0, 1.0, 2.0, 6.0) AS rank
                  FROM nodes_fts
                  JOIN nodes n ON nodes_fts.rowid = n.rowid
                  WHERE nodes_fts MATCH ?1
-                 ORDER BY bm25(nodes_fts, 10.0, 5.0, 1.0, 2.0)
+                 ORDER BY bm25(nodes_fts, 10.0, 5.0, 1.0, 2.0, 6.0)
                  LIMIT ?2",
                 params![fts_query, limit as i64],
             )

--- a/src/text.rs
+++ b/src/text.rs
@@ -18,9 +18,138 @@ pub fn utf8_prefix_at_or_before(s: &str, max_bytes: usize) -> &str {
     &s[..end]
 }
 
+/// Split a compound name into individual words.
+///
+/// Handles camelCase, `PascalCase`, and `snake_case`:
+/// - `getUserName` → `["get", "User", "Name"]`
+/// - `process_request` → `["process", "request"]`
+/// - `MAX_RETRIES` → `["MAX", "RETRIES"]`
+pub fn split_compound(name: &str) -> Vec<&str> {
+    if name.contains('_') {
+        return name.split('_').filter(|s| !s.is_empty()).collect();
+    }
+
+    // camelCase / PascalCase splitting
+    let bytes = name.as_bytes();
+    let mut parts = Vec::new();
+    let mut start = 0;
+
+    for i in 1..bytes.len() {
+        let cur = bytes[i] as char;
+        let prev = bytes[i - 1] as char;
+
+        // Split at lowercase→uppercase boundary (e.g. getUser → get|User)
+        let boundary = prev.is_ascii_lowercase() && cur.is_ascii_uppercase();
+        // Split at uppercase→uppercase+lowercase (e.g. XMLParser → XML|Parser)
+        let acronym_end = i + 1 < bytes.len()
+            && prev.is_ascii_uppercase()
+            && cur.is_ascii_uppercase()
+            && (bytes[i + 1] as char).is_ascii_lowercase();
+
+        if boundary || acronym_end {
+            if i > start {
+                parts.push(&name[start..i]);
+            }
+            start = i;
+        }
+    }
+    if start < name.len() {
+        parts.push(&name[start..]);
+    }
+    parts
+}
+
+/// Returns `true` if `word` looks like CamelCase.
+///
+/// The word must contain at least one uppercase letter after the first character
+/// and consist only of ASCII alphanumeric characters.
+pub fn is_camel_case(word: &str) -> bool {
+    if word.len() < 2 {
+        return false;
+    }
+    // Must be all alphanumeric
+    if !word.chars().all(|c| c.is_ascii_alphanumeric()) {
+        return false;
+    }
+    // Must have at least one uppercase letter after the first char
+    word[1..].chars().any(|c| c.is_ascii_uppercase())
+}
+
+/// Space-joined camelCase word segments for the FTS `search_terms` column.
+///
+/// The unicode61 tokenizer already splits on every non-alphanumeric byte
+/// (`_`, `::`, `/`, `.`), so `snake_case` names and path segments are indexed
+/// as separate tokens on their own. What it cannot derive are the words
+/// inside a camelCase identifier — `updateCloudClient` stays one token.
+/// Emit only those inner words, deduplicated case-insensitively, so the
+/// column adds signal without repeating what the tokenizer already produces.
+#[must_use]
+pub fn search_terms(name: &str, qualified_name: &str) -> String {
+    let mut seen = std::collections::HashSet::new();
+    let mut out: Vec<&str> = Vec::new();
+    for word in name
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .chain(qualified_name.split(|c: char| !c.is_ascii_alphanumeric()))
+    {
+        if !is_camel_case(word) {
+            continue;
+        }
+        for part in split_compound(word) {
+            if part.len() >= 2 && seen.insert(part.to_ascii_lowercase()) {
+                out.push(part);
+            }
+        }
+    }
+    out.join(" ")
+}
+
 #[cfg(test)]
 mod tests {
-    use super::utf8_prefix_at_or_before;
+    use super::{is_camel_case, search_terms, split_compound, utf8_prefix_at_or_before};
+
+    #[test]
+    fn split_compound_handles_camel_snake_screaming() {
+        assert_eq!(split_compound("getUserName"), vec!["get", "User", "Name"]);
+        assert_eq!(
+            split_compound("process_request"),
+            vec!["process", "request"]
+        );
+        assert_eq!(split_compound("MAX_RETRIES"), vec!["MAX", "RETRIES"]);
+        assert_eq!(split_compound("XMLParser"), vec!["XML", "Parser"]);
+    }
+
+    #[test]
+    fn is_camel_case_classifies() {
+        assert!(is_camel_case("UserService"));
+        assert!(is_camel_case("processRequest"));
+        assert!(!is_camel_case("user"));
+        assert!(!is_camel_case("U"));
+        assert!(!is_camel_case("process_request"));
+    }
+
+    #[test]
+    fn search_terms_emits_camel_parts_only() {
+        // Snake_case name: unicode61 already splits it — nothing to add.
+        assert_eq!(
+            search_terms(
+                "rerank_candidates",
+                "src/context/ranking.rs::rerank_candidates"
+            ),
+            ""
+        );
+        // CamelCase name and path segment produce inner words.
+        let terms = search_terms(
+            "updateCloudClient",
+            "src/api/CloudSync.ts::updateCloudClient",
+        );
+        assert_eq!(terms, "update Cloud Client Sync");
+    }
+
+    #[test]
+    fn search_terms_dedupes_case_insensitively() {
+        let terms = search_terms("ParseJson", "parser/ParseJson.kt::ParseJson");
+        assert_eq!(terms, "Parse Json");
+    }
 
     #[test]
     fn returns_whole_string_when_under_budget() {

--- a/tests/db_test.rs
+++ b/tests/db_test.rs
@@ -534,6 +534,141 @@ async fn test_migrate_is_idempotent_at_latest() {
     assert!(!migrated, "second migrate should be a no-op");
 }
 
+// --- v14: search_terms column + porter FTS ---
+
+#[tokio::test]
+async fn test_migrate_v14_backfills_search_terms_and_rebuilds_fts() {
+    let dir = TempDir::new().expect("tempdir");
+    let db_path = dir.path().join("v13.db");
+
+    let lib_db = libsql::Builder::new_local(&db_path)
+        .build()
+        .await
+        .expect("build db");
+    let conn = lib_db.connect().expect("connect");
+
+    // v13-shaped schema: nodes without search_terms, 4-column unicode61 FTS.
+    conn.execute_batch(
+        "CREATE TABLE nodes (
+            id TEXT PRIMARY KEY,
+            kind TEXT NOT NULL,
+            name TEXT NOT NULL,
+            qualified_name TEXT NOT NULL,
+            file_path TEXT NOT NULL,
+            start_line INTEGER NOT NULL,
+            end_line INTEGER NOT NULL,
+            start_column INTEGER NOT NULL,
+            end_column INTEGER NOT NULL,
+            docstring TEXT,
+            signature TEXT,
+            updated_at INTEGER NOT NULL,
+            attrs_start_line INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE VIRTUAL TABLE nodes_fts USING fts5(
+            name, qualified_name, docstring, signature,
+            content='nodes', content_rowid='rowid'
+        );
+        CREATE TRIGGER nodes_fts_insert AFTER INSERT ON nodes BEGIN
+            INSERT INTO nodes_fts(rowid, name, qualified_name, docstring, signature)
+            VALUES (NEW.rowid, NEW.name, NEW.qualified_name, NEW.docstring, NEW.signature);
+        END;
+        INSERT INTO nodes (id, kind, name, qualified_name, file_path,
+                           start_line, end_line, start_column, end_column, updated_at)
+        VALUES ('camel', 'function', 'updateCloudClient',
+                'src/api/CloudSync.ts::updateCloudClient', 'src/api/CloudSync.ts',
+                1, 5, 0, 1, 1000),
+               ('snake', 'function', 'rerank_candidates',
+                'src/context/ranking.rs::rerank_candidates', 'src/context/ranking.rs',
+                10, 20, 0, 1, 1000);
+        PRAGMA user_version = 13;",
+    )
+    .await
+    .expect("v13 schema setup");
+
+    let migrated = tokensave::db::migrations::migrate(&conn)
+        .await
+        .expect("migrate failed");
+    assert!(migrated, "expected v14 migration to run");
+
+    let mut rows = conn
+        .query("PRAGMA user_version", ())
+        .await
+        .expect("read version");
+    let v: u32 = rows
+        .next()
+        .await
+        .expect("version row")
+        .expect("version missing")
+        .get(0)
+        .expect("version value");
+    assert_eq!(v, latest_version());
+
+    // Backfill: camelCase row gets inner-word segments, snake_case stays empty.
+    let mut rows = conn
+        .query("SELECT search_terms FROM nodes WHERE id = 'camel'", ())
+        .await
+        .expect("select camel");
+    let terms: String = rows
+        .next()
+        .await
+        .expect("camel row")
+        .expect("camel missing")
+        .get(0)
+        .expect("terms");
+    assert!(
+        terms.contains("Cloud") && terms.contains("Client"),
+        "{terms}"
+    );
+    let mut rows = conn
+        .query("SELECT search_terms FROM nodes WHERE id = 'snake'", ())
+        .await
+        .expect("select snake");
+    let terms: String = rows
+        .next()
+        .await
+        .expect("snake row")
+        .expect("snake missing")
+        .get(0)
+        .expect("terms");
+    assert!(terms.is_empty(), "snake_case needs no extra terms: {terms}");
+
+    // Rebuilt FTS matches a camelCase inner word via search_terms…
+    let mut rows = conn
+        .query(
+            "SELECT n.id FROM nodes_fts JOIN nodes n ON nodes_fts.rowid = n.rowid
+             WHERE nodes_fts MATCH 'cloud'",
+            (),
+        )
+        .await
+        .expect("fts cloud");
+    let id: String = rows
+        .next()
+        .await
+        .expect("cloud row")
+        .expect("no match for 'cloud'")
+        .get(0)
+        .expect("id");
+    assert_eq!(id, "camel");
+
+    // …and porter stemming lets an inflected query term match the identifier.
+    let mut rows = conn
+        .query(
+            "SELECT n.id FROM nodes_fts JOIN nodes n ON nodes_fts.rowid = n.rowid
+             WHERE nodes_fts MATCH 'candidate'",
+            (),
+        )
+        .await
+        .expect("fts candidate");
+    let id: String = rows
+        .next()
+        .await
+        .expect("candidate row")
+        .expect("no match for 'candidate' (porter stemming inactive?)")
+        .get(0)
+        .expect("id");
+    assert_eq!(id, "snake");
+}
+
 #[tokio::test]
 async fn test_search_nodes_bounded_returns_real_descending_scores() {
     let (db, _dir) = setup_db().await;


### PR DESCRIPTION
Finding 3 of #313. Stacked on #314 and #315 (review the last commit).

## Problem

FTS matching is exact-token: "candidates" never matches `candidate`, "truncation" never matches `truncate` (#264 noted the missing `generates` → `generate` normalization). Two query-side workarounds compensate — the trailing-`s` strip and `generate_stem_variants`' hand-rolled suffix table — covering the common inflections and missing the rest.

## Changes

- `nodes_fts` rebuilt with `tokenize='porter unicode61'`: inflected prose stems to indexed identifiers at match time.
- **Both workarounds deleted** (net −201 lines). Evidence: porter conflates every pair the suffix table targets (verified in FTS5: authentication ↔ authenticator ↔ authenticate, configuration ↔ configure, serializer ↔ serialization, truncation ↔ truncate, validator ↔ validated; the one jump neither makes is resolution → resolve). With porter active, the 12-query eval returns identical entry points with the workarounds removed.
- New `search_terms` column: camelCase inner words the tokenizer cannot derive (`updateCloudClient` → `Cloud Client`), computed at insert time by `text::search_terms`, weighted 6.0 in `bm25()`. Empty for snake_case names — unicode61 already splits `_`. No-op for this repo; closes the #202 class at the index for TS/Java/Go corpora.
- `split_compound`/`is_camel_case` move to the shared `text` module so the DB layer can reuse them; behavior unchanged.
- Migration v14: add column, Rust-side backfill, recreate `nodes_fts` + triggers, FTS rebuild. Derived data only — worst case is a re-index; no user-authored state is touched. Fresh-install schema mirrors the DDL.

## Verification

- Migration test: v13-shaped DB → v14 with backfilled `search_terms`, camelCase inner-word FTS hit, porter matching an inflected term.
- Full suite: 2780 passed, 0 failed.
- 12-query eval from #313: identical results to #315 (66% hit@3) — zero retrieval cost for a net-negative diff. Porter's headroom is inflections the deleted table never covered, and camelCase corpora this eval (a Rust repo) cannot exercise.

If deleting `generate_stem_variants` feels too aggressive for one PR, it splits out cleanly — say the word.
