### PR TITLE
fix: stamp index version and order bulk load before clear (#320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project uses [maintenance-based versioning](TOKENSAVE-VERSIONING.md), n
 
 ## [Unreleased]
 
+### Fixed
+- **A project indexed by the CLI no longer force-reindexes on the first MCP tool call of every session, and a failed forced reindex no longer leaves the project with an empty index.** `last_indexed_version` was written only by the MCP server's `run_version_reindex`, so every project created by `tokensave init` kept the `String::new()` default. `bump_kind("", running)` classifies an unparseable `old` as `BumpKind::Major`, so the first `tools/call` of each session logged `major upgrade or schema change detected (indexed by "", running <version>) — forcing project reindex…` and ran a full reindex — on a project that was already current. `index_all` opened that reindex with `db.clear()` *before* `db.begin_bulk_load()`, so when `begin_bulk_load` lost the table lock to a second tokensave process (a common setup: VS Code, VS Code Insiders, and one or more CLI agents all registered against the same project) the rows were already gone, the reindex returned early, and the marker was never advanced. The server treats that failure as non-fatal and keeps serving, so every subsequent tool call answered out of a gutted graph — observed as `file_count: 1` on a 259-file project — and the same destructive cycle repeated on the next start, since the marker still said `""`. A full index now records the running version, so the redundant reindex never starts; and `begin_bulk_load` runs before `clear`, so a lock failure aborts with the previous index intact instead of destroying it. Clearing after the FTS triggers are dropped also avoids firing a per-row FTS delete trigger for every node.
+
 
 ## [7.8.1] - 2026-07-27
 

--- a/src/tokensave/indexing.rs
+++ b/src/tokensave/indexing.rs
@@ -255,9 +255,12 @@ impl TokenSave {
         write_dirty_sentinel(&self.project_root);
         let start = Instant::now();
 
-        // 1. Clear existing data and enter bulk-load mode
-        self.db.clear().await?;
+        // 1. Enter bulk-load mode, then clear existing data. Order matters:
+        // `begin_bulk_load` can fail while another process holds the table
+        // lock, and clearing first would leave the project with an empty index
+        // that the MCP server then keeps serving (#320).
         self.db.begin_bulk_load().await?;
+        self.db.clear().await?;
 
         // 2. Scan for source files
         let phase_start = Instant::now();
@@ -429,8 +432,33 @@ impl TokenSave {
             "non-empty index completed in zero milliseconds"
         );
         clear_dirty_sentinel(&self.project_root);
+        self.record_indexed_version();
         crate::memstats::record("index:done");
         Ok(result)
+    }
+
+    /// Records the running version as the one that produced the current index.
+    ///
+    /// Without this, a project indexed by the CLI keeps `last_indexed_version`
+    /// empty, which `bump_kind` classifies as a major bump — so the MCP server
+    /// forces a full reindex on the first tool call of every session (#320).
+    ///
+    /// Best-effort: failing to persist the marker must not fail an index that
+    /// otherwise succeeded.
+    fn record_indexed_version(&self) {
+        let running = env!("CARGO_PKG_VERSION");
+        match crate::config::load_config(&self.project_root) {
+            Ok(mut config) if config.last_indexed_version != running => {
+                config.last_indexed_version = running.to_string();
+                if let Err(e) = crate::config::save_config(&self.project_root, &config) {
+                    eprintln!("[tokensave] failed to record indexed version: {e}");
+                }
+            }
+            Ok(_) => {}
+            Err(e) => {
+                eprintln!("[tokensave] failed to load config to record indexed version: {e}")
+            }
+        }
     }
 
     /// Performs an incremental sync: detects changed, new, and removed files

--- a/tests/mcp_server_test.rs
+++ b/tests/mcp_server_test.rs
@@ -1819,7 +1819,7 @@ async fn search_call_writes_savings_ledger_row() {
 // Version-aware forced reindex on first tool call (#v11)
 // ---------------------------------------------------------------------------
 
-/// A fresh project starts with an empty `last_indexed_version`. The first
+/// A pre-7.0 project carries an empty `last_indexed_version`. The first
 /// `tools/call` must trigger a background forced reindex that, on completion,
 /// advances the marker in the persisted project config to the running version.
 #[tokio::test]
@@ -1835,7 +1835,12 @@ async fn test_first_tool_call_backfills_last_indexed_version() {
     let cg = TokenSave::init(project).await.unwrap();
     cg.index_all().await.unwrap();
 
-    // Sanity: brand-new config has no recorded indexed version.
+    // `index_all` now stamps the marker (#320), so reset it to reproduce the
+    // pre-7.0 state that this backfill path exists to handle.
+    let mut seed = tokensave::config::load_config(project).unwrap();
+    seed.last_indexed_version = String::new();
+    tokensave::config::save_config(project, &seed).unwrap();
+
     let before = tokensave::config::load_config(project).unwrap();
     assert_eq!(before.last_indexed_version, "");
 
@@ -1888,6 +1893,70 @@ async fn test_first_tool_call_keeps_current_marker() {
     let mut config = tokensave::config::load_config(project).unwrap();
     config.last_indexed_version = env!("CARGO_PKG_VERSION").to_string();
     tokensave::config::save_config(project, &config).unwrap();
+
+    let server = McpServer::new(cg, None).await;
+    let server_for_drive = Arc::clone(&server);
+    let _ = run_server_with_messages(
+        server_for_drive,
+        vec![jsonrpc_request(
+            json!(1),
+            "tools/call",
+            json!({
+                "name": "tokensave_search",
+                "arguments": { "query": "main" }
+            }),
+        )],
+    )
+    .await;
+
+    let completed = server
+        .wait_for_version_reindex(std::time::Duration::from_secs(30))
+        .await;
+    assert!(completed, "version reindex gate did not settle in time");
+
+    let after = tokensave::config::load_config(project).unwrap();
+    assert_eq!(after.last_indexed_version, env!("CARGO_PKG_VERSION"));
+}
+
+/// A full index records the version that produced it, so a CLI-indexed project
+/// is not mistaken for a pre-7.0 one and force-reindexed on the first tool call
+/// of every session (#320).
+#[tokio::test]
+async fn test_index_all_records_running_version() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(
+        project.join("src/main.rs"),
+        "fn main() { let x = helper(); }\nfn helper() -> i32 { 42 }\n",
+    )
+    .unwrap();
+    let cg = TokenSave::init(project).await.unwrap();
+    cg.index_all().await.unwrap();
+
+    let config = tokensave::config::load_config(project).unwrap();
+    assert_eq!(
+        config.last_indexed_version,
+        env!("CARGO_PKG_VERSION"),
+        "a full index must record the version that produced it"
+    );
+}
+
+/// A project indexed by the running version must not trigger a forced reindex
+/// on the first tool call, so the index is never cleared for no reason (#320).
+#[tokio::test]
+async fn test_cli_indexed_project_needs_no_forced_reindex() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(
+        project.join("src/main.rs"),
+        "fn main() { let x = helper(); }\nfn helper() -> i32 { 42 }\n",
+    )
+    .unwrap();
+    let cg = TokenSave::init(project).await.unwrap();
+    let indexed = cg.index_all().await.unwrap();
+    assert!(indexed.node_count > 0, "fixture should produce nodes");
 
     let server = McpServer::new(cg, None).await;
     let server_for_drive = Arc::clone(&server);


### PR DESCRIPTION
> **Disclosure: this PR was written by an AI coding agent** (GitHub Copilot), driven by the user who reported #320, and is offered as a **potential** fix rather than a confirmed one. The root-cause analysis below is derived from reading the source and from reproduction logs on a real project, but the maintainer should judge whether this is the intended fix — particularly the ordering change in `index_all`, which touches the destructive path. Please review accordingly.

Potential fix for #320.

## Problem

Two independent defects compound into a destructive loop.

**1. `last_indexed_version` is never written by the CLI.**

The marker is written in exactly two places, both in `src/mcp/server.rs::run_version_reindex`. `tokensave init` / `index_all` never write it, so every CLI-initialised project keeps the `String::new()` default.

`cloud::bump_kind("", running)` cannot parse the empty old version, so it returns `BumpKind::Major`. The result is that the first `tools/call` of **every** session on **every** CLI-indexed project logs:

```
[tokensave] major upgrade or schema change detected (indexed by "", running 7.8.1) — forcing project reindex…
```

and runs a full reindex of a project that is already current.

**2. `index_all` clears the database before it acquires bulk-load mode.**

```rust
self.db.clear().await?;
self.db.begin_bulk_load().await?;
```

`begin_bulk_load` drops 14 indexes and 7 triggers, so it needs the table lock. When a second tokensave process holds it — a common setup, since `tokensave install` registers VS Code, VS Code Insiders and one or more CLI agents against the same project and DB — it fails with:

```
[tokensave] version reindex failed: database error: failed to begin bulk load:
SQLite failure: `database table is locked` (operation: begin_bulk_load)
```

By then `clear()` has already deleted every row. Note `busy_timeout` does not help here: this is `SQLITE_LOCKED`, not `SQLITE_BUSY`.

**The compounding.** `run_version_reindex` treats the failure as non-fatal and `return`s early, so the marker is *never* advanced. The server keeps serving out of the now-empty graph, and because the marker still reads `""`, the next start repeats the whole cycle. Observed on a 259-file project — two consecutive `tokensave_status` calls against the same DB:

| run | `file_count` | `node_count` |
| --- | --- | --- |
| 1   | **1**        | **264**      |
| 2   | 258          | 7,464        |

`tokensave doctor` reports the project fully healthy throughout, so the condition is invisible unless you read stderr.

## Changes

**`src/tokensave/indexing.rs`**

1. Swap the order to `begin_bulk_load()` → `clear()`. A lock failure now aborts with the previous index **intact** instead of destroying it. This is safe because `db::queries::clear::clear()` issues explicit `DELETE`s against all seven tables and does not rely on FK cascade, so it does not depend on the `PRAGMA foreign_keys = OFF` / index-drop state either way. It is also slightly faster: the FTS triggers are already dropped, so the `DELETE FROM nodes` no longer fires a per-row FTS delete trigger.
2. Add `record_indexed_version()`, called after a successful index, so a CLI-indexed project no longer looks pre-7.0 and the redundant forced reindex never starts. It is best-effort — a failure to persist the marker is reported on stderr but does not fail an index that otherwise succeeded — and it skips the write when the value is already current, to avoid rewriting `config.toml` on every index.

Only the first change is needed to stop the data loss; only the second stops the needless reindex. They are kept together because the bug requires both to reproduce.

## Tests

**Modified — please look at this one.** `test_first_tool_call_backfills_last_indexed_version` relied on `index_all` leaving the marker empty, i.e. its premise encoded the bug. Its actual intent — that a **pre-7.0** project gets backfilled on first tool call — is still valuable, so rather than delete it I made the legacy state explicit: it now resets the marker to `""` after indexing before exercising the backfill path.

**Added:**
- `test_index_all_records_running_version` — a full index records the version that produced it.
- `test_cli_indexed_project_needs_no_forced_reindex` — drives a real `tokensave_search` call through `run_server_with_messages` against a CLI-indexed project and asserts the marker is correct after the version-reindex gate settles.

I did **not** add a test for the ordering change. Deterministically inducing `SQLITE_LOCKED` on `begin_bulk_load` from inside the test harness did not look reliable, and I would rather flag the gap than land a flaky test. Suggestions welcome if you know a good way to force it.

## Verification

Toolchain 1.95.0 per `rust-toolchain.toml`, built with `--no-default-features --features lite,test-transport`:

- `cargo fmt --check` — clean
- `cargo clippy --all-targets` — no new warnings
- `cargo test --test mcp_server_test` — **44 passed, 0 failed**
- `cargo test --test config_test` — **34 passed, 0 failed** (incl. `test_last_indexed_version_persists`, `test_legacy_config_without_last_indexed_version_loads_empty`)
- Full suite — one pre-existing failure cluster: 7 doc-related tests in `mcp_handler_test.rs` fail under `lite`. **Confirmed pre-existing**, identical 184 passed / 7 failed with my changes stashed on a clean `797207a`. They appear to need a language feature that `lite` disables; the full feature set was not built locally.

`CHANGELOG.md` updated under `[Unreleased] → Fixed`.
