### PR TITLE
fix(dart): extract calls inside closures and local functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project uses [maintenance-based versioning](TOKENSAVE-VERSIONING.md), n
 
 ## [Unreleased]
 
+### Fixed
+- **Dart calls made inside closures and local functions are no longer dropped.** `extract_call_sites` skipped `function_expression`/`lambda_expression` outright instead of attributing their calls to the enclosing named symbol, so calls inside Flutter callbacks (`onPressed:`, `builder:`, `setState(…)`, `.map(…)`) and local functions were invisible to `tokensave_callers`, `tokensave_impact`, and `tokensave_dead_code` — a helper reached only from a callback looked dead. Same fix as TypeScript #209 for nested arrows.
 
 ## [7.8.1] - 2026-07-27
 

--- a/src/extraction/dart_extractor.rs
+++ b/src/extraction/dart_extractor.rs
@@ -1697,8 +1697,16 @@ impl DartExtractor {
                     // Recurse into argument_part for nested calls.
                     Self::extract_call_sites(state, child, fn_node_id);
                 }
-                // Skip nested function expressions to avoid polluting call sites.
-                "function_expression" | "lambda_expression" => {}
+                // Closures and local functions have no graph node of their own, so their
+                // calls belong to the enclosing named symbol. `function_expression` is the
+                // anonymous form (`() { … }`, `(x) => …`) that carries nearly every Flutter
+                // callback — `onPressed:`, `builder:`, `setState(…)`, `.map(…)` — and
+                // `lambda_expression` is the named local-function form. Both were skipped
+                // outright, so those calls were discarded rather than reattributed. Same fix
+                // as #209 for TypeScript arrows.
+                "function_expression" | "lambda_expression" => {
+                    Self::extract_call_sites(state, child, fn_node_id);
+                }
                 _ => {
                     // Recurse into other nodes.
                     Self::extract_call_sites(state, child, fn_node_id);

--- a/tests/dart_extraction_test.rs
+++ b/tests/dart_extraction_test.rs
@@ -602,3 +602,94 @@ fn test_dart_field_type_uses_ref() {
         result.unresolved_refs
     );
 }
+
+// --- Regression tests: calls inside closures and local functions (P0-1) ---
+//
+// `function_expression` (anonymous closures: `() { … }`, `(x) => …`) and
+// `lambda_expression` (named local functions) have no graph node of their
+// own, so their calls must be attributed to the enclosing named symbol
+// rather than discarded. Same fix as TypeScript #209 for nested arrows.
+
+fn calls_from(result: &ExtractionResult, from_name_contains: &str) -> Vec<String> {
+    let ids: Vec<&str> = result
+        .nodes
+        .iter()
+        .filter(|n| n.name.contains(from_name_contains))
+        .map(|n| n.id.as_str())
+        .collect();
+    result
+        .unresolved_refs
+        .iter()
+        .filter(|r| r.reference_kind == EdgeKind::Calls && ids.contains(&r.from_node_id.as_str()))
+        .map(|r| r.reference_name.clone())
+        .collect()
+}
+
+#[test]
+fn test_dart_closure_call_sites() {
+    let result = extract(
+        "class Widget {\n  void build() {\n    button(onPressed: () { _handleTap(); });\n  }\n  void _handleTap() {}\n}",
+    );
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let build_calls = calls_from(&result, "build");
+    assert!(
+        build_calls.iter().any(|c| c == "_handleTap"),
+        "expected build() to call _handleTap, got {build_calls:?}"
+    );
+}
+
+#[test]
+fn test_dart_arrow_closure_call_sites() {
+    let result =
+        extract("class Widget {\n  void build() {\n    xs.map((u) => _encode(u));\n  }\n}");
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let build_calls = calls_from(&result, "build");
+    assert!(
+        build_calls.iter().any(|c| c == "_encode"),
+        "expected build() to call _encode, got {build_calls:?}"
+    );
+}
+
+#[test]
+fn test_dart_local_function_call_sites() {
+    let result = extract(
+        "class Widget {\n  void build() {\n    void helper() {\n      _work();\n    }\n  }\n}",
+    );
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let build_calls = calls_from(&result, "build");
+    assert!(
+        build_calls.iter().any(|c| c == "_work"),
+        "expected build() to call _work, got {build_calls:?}"
+    );
+    // The local function's own name (`helper`, from `function_signature`'s
+    // `name` field) must not be misread as a call to itself.
+    assert!(
+        !build_calls.iter().any(|c| c == "helper"),
+        "helper's own signature name must not produce a bogus Calls ref, got {build_calls:?}"
+    );
+}
+
+#[test]
+fn test_dart_closure_positions_reachable() {
+    let result = extract(
+        "class Widget {\n  \
+           void fromLocalVar() {\n    final cb = () { _fromLocalVar(); };\n  }\n\n  \
+           Function fromReturn() {\n    return () => _fromReturn();\n  }\n\n  \
+           List<Widget> fromCollectionIf(bool flag) {\n    return [ if (flag) Btn(onPressed: () => _fromCollectionIf()) ];\n  }\n\n  \
+           void fromNestedClosure() {\n    List.builder(itemBuilder: (c, i) => Btn(onPressed: () => _fromNestedClosure(i)));\n  }\n\
+         }",
+    );
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    for (enclosing, callee) in [
+        ("fromLocalVar", "_fromLocalVar"),
+        ("fromReturn", "_fromReturn"),
+        ("fromCollectionIf", "_fromCollectionIf"),
+        ("fromNestedClosure", "_fromNestedClosure"),
+    ] {
+        let calls = calls_from(&result, enclosing);
+        assert!(
+            calls.iter().any(|c| c == callee),
+            "expected {enclosing}() to call {callee} (closure position not reached), got {calls:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- `extract_call_sites` skipped `function_expression`/`lambda_expression` outright, so any call made inside a Dart closure or local function was discarded instead of being attributed to the enclosing named symbol.

## Motivation

In Flutter, almost every interesting call lives inside a closure (`onPressed:`, `builder:`, `setState(...)`, `.map(...)`), so the call graph inside widget code was largely empty. `tokensave_callers`, `tokensave_impact`, `tokensave_dead_code`, and `tokensave_simplify_scan` all mis-reported as a result — a helper reached only from a callback looked dead. Same failure class TypeScript #209 fixed for nested arrow callbacks; this applies the same fix to Dart. No open issue tracks this (`gh issue list --search dart` returns only closed #172, #155, #106, #105, #50).

## Changes

- `src/extraction/dart_extractor.rs`: replaced the `"function_expression" | "lambda_expression" => {}` skip arm with an explicit recursion into the enclosing symbol's call-site scan, so calls inside closures and local functions are no longer dropped. See the commit body for the full grammar probe (against the actual runtime grammar, `tree-sitter-dart-orchard` 0.3.2) and the reachability table covering every syntactic position a closure can occupy.
- `tests/dart_extraction_test.rs`: 4 new regression tests covering named/positional-argument closures, method-chain arrows, local named functions, and the remaining closure positions (local var initializer, return position, collection-if element, nested closure-in-closure).

## Test plan

- [x] `cargo test` passes
- [x] `cargo clippy` has no new warnings
- [x] Tested manually (describe below if applicable)

`cargo test --test dart_extraction_test --no-default-features --features lang-dart` passes 33/33 (4 new). Mutation check: reverting the fix alone makes exactly the 4 new tests fail, all others stay green. `cargo test --no-default-features --features medium` is clean except 7 pre-existing, unrelated failures in `mcp_handler_test`'s doc-sidecar tests (confirmed present on `master` before this change). `cargo fmt` and `cargo clippy --workspace --all-targets` are clean.

Manually verified end-to-end against an out-of-tree Flutter app: node count unchanged (confirming no synthetic nodes were created), `calls`/`uses` edges increased as expected, `annotates`/`extends` unchanged. Spot-checked a helper reachable only from an `onPressed:` closure: it moved from a `tokensave_dead_code` false positive with zero `tokensave_callers_for` entries to correctly showing its caller and no longer appearing in dead-code output.

## Checklist

- [x] `CHANGELOG.md` updated (under `[Unreleased]` if no version bump)
- [x] No secrets, credentials, or `.env` files included
- [x] Breaking changes documented (if any) — none
