### PR TITLE
fix(resolver): stop the resolver from producing annotates edges at all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project uses [maintenance-based versioning](TOKENSAVE-VERSIONING.md), n
 ## [Unreleased]
 
 ### Fixed
+- **`annotates` edges no longer bind an annotation usage to another usage of the same annotation, including itself.** The resolver allowed an `Annotates` reference to target a sibling `AnnotationUsage` or `Decorator` node, and every extractor names that reference after the annotation itself, so any `@override`/`#[test]`/`@Override`-style usage could resolve straight to another usage instead of staying unresolved — a phantom edge affecting 11 language extractors. The resolver now never produces `annotates` edges at all; the attachment edge extractors already emit directly at the usage site is the only one, matching what every consumer reads. Schema migration v14 removes any phantom edges already stored in existing projects' databases automatically on next open, no resync required.
 - **Dart calls made inside closures and local functions are no longer dropped.** `extract_call_sites` skipped `function_expression`/`lambda_expression` outright instead of attributing their calls to the enclosing named symbol, so calls inside Flutter callbacks (`onPressed:`, `builder:`, `setState(…)`, `.map(…)`) and local functions were invisible to `tokensave_callers`, `tokensave_impact`, and `tokensave_dead_code` — a helper reached only from a callback looked dead. Same fix as TypeScript #209 for nested arrows.
 
 ## [7.8.1] - 2026-07-27

--- a/src/db/migrations.rs
+++ b/src/db/migrations.rs
@@ -15,7 +15,7 @@ use crate::errors::{Result, TokenSaveError};
 
 /// The highest migration version defined in this file. Bump this and add a
 /// new entry to `run_migration` whenever the schema changes.
-const LATEST_VERSION: u32 = 13;
+const LATEST_VERSION: u32 = 14;
 
 pub(crate) const TRAIT_DISPATCH_TRIGGERS_SQL: &str = r"
 CREATE TRIGGER IF NOT EXISTS trait_dispatch_call_insert
@@ -431,6 +431,7 @@ async fn run_migration(conn: &Connection, version: u32) -> Result<()> {
         11 => migrate_v11(conn).await,
         12 => migrate_v12(conn).await,
         13 => migrate_v13(conn).await,
+        14 => migrate_v14(conn).await,
         _ => Err(TokenSaveError::Database {
             message: format!("unknown migration version: {version}"),
             operation: "run_migration".to_string(),
@@ -1130,6 +1131,79 @@ async fn migrate_v13(conn: &Connection) -> Result<()> {
                 operation: "migrate_v13".to_string(),
             })?;
     }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Migration V14: remove phantom annotation-usage-to-annotation-usage edges
+// ---------------------------------------------------------------------------
+
+/// One-shot data repair for the resolver bug fixed alongside this migration:
+/// `kind_compatible` used to accept `NodeKind::AnnotationUsage` and
+/// `NodeKind::Decorator` as valid targets for `EdgeKind::Annotates`, which let
+/// an annotation reference bind to a sibling usage in the same file instead of
+/// staying unresolved. The resolver now never produces `annotates` edges at
+/// all (`kind_compatible` returns `false` for the whole edge kind); the only
+/// `annotates` edges left are the ones extractors emit directly.
+///
+/// The delete targets both `annotation_usage` and `decorator` nodes:
+/// - `annotation_usage` is always a usage site, never a legitimate target of
+///   an `annotates` edge.
+/// - `decorator` is emitted at the `@foo(...)` application site (Python,
+///   TypeScript), never at the declaration it decorates, so it can never be a
+///   legitimate target either — only ever a source, including for stacked
+///   decorators (`@a @b def f`).
+///
+/// This does *not* widen to `annotation` nodes: `@Retention @interface Foo {}`
+/// is a legitimate direct edge to a `NodeKind::Annotation` node, so deleting
+/// by that target kind would remove real data. Any stale resolver-produced
+/// edges that happened to target an `annotation` node are cleared by the full
+/// reindex `TokenSave::open` already forces on any migration.
+///
+/// New databases (and any file re-synced with the fixed resolver) never
+/// produce these edges in the first place; this migration only repairs rows
+/// already stored in databases indexed before the fix.
+///
+/// Gated on the `edges` table actually existing — some pre-v9 migration
+/// tests seed a nodes-only schema and drive `migrate` all the way to
+/// `LATEST_VERSION`, and a real install always has the table by v1.
+async fn migrate_v14(conn: &Connection) -> Result<()> {
+    let mut edge_table = conn
+        .query(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'edges'",
+            (),
+        )
+        .await
+        .map_err(|e| TokenSaveError::Database {
+            message: format!("v14: failed to inspect edges table: {e}"),
+            operation: "migrate_v14".to_string(),
+        })?;
+    let has_edges = edge_table
+        .next()
+        .await
+        .map_err(|e| TokenSaveError::Database {
+            message: format!("v14: failed to read edges table status: {e}"),
+            operation: "migrate_v14".to_string(),
+        })?
+        .is_some();
+    drop(edge_table);
+
+    if has_edges {
+        conn.execute(
+            "DELETE FROM edges
+             WHERE kind = 'annotates'
+               AND target IN (
+                   SELECT id FROM nodes WHERE kind IN ('annotation_usage', 'decorator')
+               )",
+            (),
+        )
+        .await
+        .map_err(|e| TokenSaveError::Database {
+            message: format!("v14: failed to delete phantom annotates edges: {e}"),
+            operation: "migrate_v14".to_string(),
+        })?;
+    }
+
     Ok(())
 }
 

--- a/src/resolution/resolver.rs
+++ b/src/resolution/resolver.rs
@@ -932,10 +932,23 @@ fn kind_compatible(uref: &UnresolvedRef, target_kind: &NodeKind) -> bool {
                 | NodeKind::Procedure
                 | NodeKind::Macro
         ),
-        EdgeKind::Annotates => matches!(
-            target_kind,
-            NodeKind::Annotation | NodeKind::Decorator | NodeKind::AnnotationUsage
-        ),
+        // `annotates` names exactly one relation to every consumer:
+        // attachment of an annotation/decorator usage to the item it
+        // decorates (`get_annotation_sites`, `get_test_annotated_node_ids`,
+        // `get_files_with_test_annotations`,
+        // `populate_test_annotated_targets_temp_table`). Extractors already
+        // emit that edge directly at the usage site — this resolver has no
+        // second, distinct relation to express under the same edge kind.
+        //
+        // `AnnotationUsage` and `Decorator` are both usage-site kinds, not
+        // declarations: allowing either as a ref target let a lone-candidate
+        // usage resolve to *itself* or to a sibling usage of the same name
+        // (96% of `annotates` edges in this repo were this phantom pattern).
+        // `Annotation` is a real declaration (Java `@interface`), but no
+        // consumer reads a resolver-produced usage → declaration edge as
+        // attachment, so binding to it is equally wrong under this kind.
+        // A ref that matches nothing simply stays unresolved.
+        EdgeKind::Annotates => false,
         // Uses / TypeOf / Returns / Contains / Receives — permissive.
         _ => true,
     }

--- a/tests/migration_test.rs
+++ b/tests/migration_test.rs
@@ -674,6 +674,131 @@ async fn test_migrate_v13_repairs_missing_trait_dispatch_cache() {
     assert!(index_exists(&conn, "idx_trait_dispatch_callers_concrete").await);
 }
 
+/// V14 removes phantom `annotates` edges that target an `annotation_usage`
+/// node (the bug fixed alongside this migration), but leaves every
+/// legitimate `annotates` edge — direct extractor-emitted and resolver-
+/// resolved alike — untouched.
+#[tokio::test]
+async fn test_v14_removes_phantom_annotates_edges() {
+    let (conn, _db, _dir) = create_raw_db().await;
+    create_schema(&conn)
+        .await
+        .expect("create_schema should succeed");
+    set_user_version(&conn, 13).await;
+
+    let insert_node = |id: &str, kind: &str| {
+        format!(
+            "INSERT INTO nodes (id, kind, name, qualified_name, file_path, start_line, end_line, start_column, end_column, updated_at) \
+             VALUES ('{id}', '{kind}', '{id}', '{id}', 'src/lib.rs', 1, 1, 0, 1, 1000)"
+        )
+    };
+
+    // Two annotation_usage nodes in the same file, with a phantom
+    // usage-to-usage `annotates` edge between them plus a phantom self-edge.
+    conn.execute(&insert_node("usage1", "annotation_usage"), ())
+        .await
+        .expect("failed to insert usage1");
+    conn.execute(&insert_node("usage2", "annotation_usage"), ())
+        .await
+        .expect("failed to insert usage2");
+
+    // A legitimate direct edge: usage -> the item it annotates.
+    conn.execute(&insert_node("fn1", "function"), ())
+        .await
+        .expect("failed to insert fn1");
+
+    // The `@Retention @interface Foo {}` direct-edge case: a usage naming a
+    // real Annotation declaration is a legitimate extractor-emitted edge, not
+    // a resolver-produced usage-to-usage phantom.
+    conn.execute(&insert_node("usage3", "annotation_usage"), ())
+        .await
+        .expect("failed to insert usage3");
+    conn.execute(&insert_node("decl1", "annotation"), ())
+        .await
+        .expect("failed to insert decl1");
+
+    // A phantom edge targeting a `decorator` node: decorator nodes are only
+    // ever emitted at the application site, never the declaration, so a
+    // usage -> decorator edge is the same phantom class as usage -> usage.
+    conn.execute(&insert_node("usage4", "annotation_usage"), ())
+        .await
+        .expect("failed to insert usage4");
+    conn.execute(&insert_node("dec1", "decorator"), ())
+        .await
+        .expect("failed to insert dec1");
+
+    // A legitimate direct edge with a decorator as *source*: proves the
+    // delete keys on target kind, not on `decorator` appearing anywhere in
+    // the edge.
+    conn.execute(&insert_node("fn2", "function"), ())
+        .await
+        .expect("failed to insert fn2");
+
+    conn.execute(
+        "INSERT INTO edges (source, target, kind, line) VALUES ('usage1', 'usage2', 'annotates', 1)",
+        (),
+    )
+    .await
+    .expect("failed to insert phantom cross-node edge");
+    conn.execute(
+        "INSERT INTO edges (source, target, kind, line) VALUES ('usage1', 'usage1', 'annotates', 1)",
+        (),
+    )
+    .await
+    .expect("failed to insert phantom self-edge");
+    conn.execute(
+        "INSERT INTO edges (source, target, kind, line) VALUES ('usage2', 'fn1', 'annotates', 1)",
+        (),
+    )
+    .await
+    .expect("failed to insert legitimate direct edge");
+    conn.execute(
+        "INSERT INTO edges (source, target, kind, line) VALUES ('usage3', 'decl1', 'annotates', 1)",
+        (),
+    )
+    .await
+    .expect("failed to insert direct annotation-usage-to-declaration edge");
+    conn.execute(
+        "INSERT INTO edges (source, target, kind, line) VALUES ('usage4', 'dec1', 'annotates', 1)",
+        (),
+    )
+    .await
+    .expect("failed to insert phantom usage-to-decorator edge");
+    conn.execute(
+        "INSERT INTO edges (source, target, kind, line) VALUES ('dec1', 'fn2', 'annotates', 1)",
+        (),
+    )
+    .await
+    .expect("failed to insert legitimate decorator-as-source edge");
+
+    assert!(migrate(&conn).await.expect("v14 migration should succeed"));
+    assert_eq!(get_user_version(&conn).await, latest_version());
+
+    let mut rows = conn
+        .query(
+            "SELECT source, target FROM edges WHERE kind = 'annotates' ORDER BY source",
+            (),
+        )
+        .await
+        .expect("failed to query surviving annotates edges");
+    let mut surviving = Vec::new();
+    while let Some(row) = rows.next().await.expect("failed to read row") {
+        let source: String = row.get(0).expect("failed to read source");
+        let target: String = row.get(1).expect("failed to read target");
+        surviving.push((source, target));
+    }
+
+    assert_eq!(
+        surviving,
+        vec![
+            ("dec1".to_string(), "fn2".to_string()),
+            ("usage2".to_string(), "fn1".to_string()),
+            ("usage3".to_string(), "decl1".to_string()),
+        ],
+        "only edges not targeting an annotation_usage or decorator node should survive the v14 repair"
+    );
+}
+
 /// After create_schema, all v5 columns on nodes exist.
 #[tokio::test]
 async fn test_create_schema_has_all_node_columns() {

--- a/tests/resolution_test.rs
+++ b/tests/resolution_test.rs
@@ -722,6 +722,154 @@ async fn test_ruby_extends_resolves_to_class() {
 }
 
 // ---------------------------------------------------------------------------
+// The resolver never produces `annotates` edges: `kind_compatible` returns
+// `false` for every target kind under `EdgeKind::Annotates`. Extractors emit
+// the attachment edge (usage -> decorated item) directly; that is the only
+// relation `annotates` names to any consumer, so the resolver has nothing to
+// add. These tests pin that an `Annotates` ref stays unresolved against
+// every kind of candidate that could otherwise look like a match: a sibling
+// usage (self- or cross-node), a real `Annotation` declaration, and a
+// `Decorator` node (which is itself a usage-site node, not a declaration —
+// emitted at the `@foo(...)` application site, not the `def`/`class` it
+// decorates).
+// ---------------------------------------------------------------------------
+
+/// Two `@override` usages in one file, each with an `Annotates` ref named
+/// "override": neither may resolve to the other (self-edge) or to its
+/// sibling (cross-node phantom).
+#[tokio::test]
+async fn test_annotation_ref_does_not_bind_to_sibling_usage() {
+    let dir = TempDir::new().expect("failed to create temp dir");
+    let (db, _) = Database::initialize(&dir.path().join("test.db"))
+        .await
+        .expect("failed to init db");
+
+    let usage_a = variant_node(
+        "au:override:a",
+        NodeKind::AnnotationUsage,
+        "override",
+        "lib/a.dart::override",
+        "lib/a.dart",
+    );
+    let usage_b = variant_node(
+        "au:override:b",
+        NodeKind::AnnotationUsage,
+        "override",
+        "lib/a.dart::override",
+        "lib/a.dart",
+    );
+
+    let nodes = vec![usage_a.clone(), usage_b.clone()];
+    let resolver = ReferenceResolver::from_nodes(&db, &nodes);
+
+    let uref_a = UnresolvedRef {
+        from_node_id: usage_a.id.clone(),
+        reference_name: "override".to_string(),
+        reference_kind: EdgeKind::Annotates,
+        line: 1,
+        column: 1,
+        file_path: "lib/a.dart".to_string(),
+    };
+    let uref_b = UnresolvedRef {
+        from_node_id: usage_b.id.clone(),
+        reference_name: "override".to_string(),
+        reference_kind: EdgeKind::Annotates,
+        line: 5,
+        column: 1,
+        file_path: "lib/a.dart".to_string(),
+    };
+
+    assert!(
+        resolver.resolve_one(&uref_a).is_none(),
+        "an Annotates ref must not resolve to a sibling AnnotationUsage (self or cross-node)"
+    );
+    assert!(
+        resolver.resolve_one(&uref_b).is_none(),
+        "an Annotates ref must not resolve to a sibling AnnotationUsage (self or cross-node)"
+    );
+}
+
+/// An `Annotates` ref must not resolve to a real `Annotation` declaration
+/// (e.g. Java `@interface`) either: the resolver produces no `annotates`
+/// edges at all, since the extractor already emits the attachment edge
+/// directly and no consumer reads a resolver-produced usage -> declaration
+/// edge under this kind as attachment.
+#[tokio::test]
+async fn test_annotation_ref_does_not_bind_to_declaration() {
+    let dir = TempDir::new().expect("failed to create temp dir");
+    let (db, _) = Database::initialize(&dir.path().join("test.db"))
+        .await
+        .expect("failed to init db");
+
+    let decl_node = variant_node(
+        "an:JsonSerializable",
+        NodeKind::Annotation,
+        "JsonSerializable",
+        "lib/model.dart::JsonSerializable",
+        "lib/model.dart",
+    );
+    let usage_node = variant_node(
+        "au:JsonSerializable",
+        NodeKind::AnnotationUsage,
+        "JsonSerializable",
+        "lib/a.dart::JsonSerializable",
+        "lib/a.dart",
+    );
+
+    let nodes = vec![decl_node, usage_node];
+    let resolver = ReferenceResolver::from_nodes(&db, &nodes);
+
+    let uref = UnresolvedRef {
+        from_node_id: "au:JsonSerializable".to_string(),
+        reference_name: "JsonSerializable".to_string(),
+        reference_kind: EdgeKind::Annotates,
+        line: 1,
+        column: 1,
+        file_path: "lib/a.dart".to_string(),
+    };
+
+    assert!(
+        resolver.resolve_one(&uref).is_none(),
+        "an Annotates ref must not resolve to an Annotation declaration"
+    );
+}
+
+/// `NodeKind::Decorator` is a usage-site node (emitted at the `@foo(...)`
+/// application site, not the declaration it decorates), so it must not be a
+/// valid `Annotates` target either.
+#[tokio::test]
+async fn test_annotation_ref_does_not_bind_to_decorator() {
+    let dir = TempDir::new().expect("failed to create temp dir");
+    let (db, _) = Database::initialize(&dir.path().join("test.db"))
+        .await
+        .expect("failed to init db");
+
+    let decorator_node = variant_node(
+        "dec:retry",
+        NodeKind::Decorator,
+        "retry",
+        "lib/decorators.py::retry",
+        "lib/decorators.py",
+    );
+
+    let resolver = ReferenceResolver::from_nodes(&db, std::slice::from_ref(&decorator_node));
+
+    let uref = UnresolvedRef {
+        from_node_id: "fn:call_api".to_string(),
+        reference_name: "retry".to_string(),
+        reference_kind: EdgeKind::Annotates,
+        line: 1,
+        column: 1,
+        file_path: "lib/api.py".to_string(),
+    };
+
+    assert!(
+        resolver.resolve_one(&uref).is_none(),
+        "an Annotates ref must not resolve to a Decorator usage node"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // #141 Option 2: build-variant call-edge propagation
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- The resolver no longer produces `annotates` edges at all: `kind_compatible`'s `EdgeKind::Annotates` arm is now `=> false`.
- Schema migration V14 repairs existing databases in place, widened to delete phantom `annotates` edges targeting either `annotation_usage` or `decorator` nodes.
- `Cargo.toml` is deliberately left at `7.8.1` — version bumps land as separate `chore(release)` commits.

## Motivation

`annotates` names exactly one relation to every consumer: attachment of an annotation/decorator usage to the item it decorates. Extractors already emit that edge directly at the usage site. The resolver's `kind_compatible` allowlist (`Annotation | Decorator`) let an `Annotates` ref additionally bind to any same-named usage node, producing phantom self-edges and cross-node edges with no consumer that reads them as attachment.

Measured before this fix (`edges e JOIN nodes t ON t.id = e.target WHERE e.kind='annotates' AND t.kind='annotation_usage'`):

| Corpus | phantom `annotates` | total `annotates` | phantom % |
|---|---|---|---|
| thingviewer (Flutter, 78 files) | 104 | 208 | 50% |
| tokensave itself (Rust, 408 files) | 3,244 | 3,457 | 94% |

`NodeKind::Decorator` was also in the allowlist on the mistaken premise that it is a declaration kind. It is not: `Decorator` is emitted at the *application* site (`@foo(...)`) and is always the *source* of the direct attachment edge, never a legitimate target. Leaving it in the allowlist kept the same phantom class alive for Python/TS, reachable via a cross-language name collision.

## Changes

- `src/resolution/resolver.rs`: `EdgeKind::Annotates => false` in `kind_compatible` — a complete kill switch, since every path that mints a `ResolvedRef` filters through this gate.
- `tests/resolution_test.rs`: kept `test_annotation_ref_does_not_bind_to_sibling_usage`; replaced two prior "positive control" tests with negative assertions that a ref must not resolve to a `NodeKind::Annotation` declaration nor to a `NodeKind::Decorator` usage node.
- `src/db/migrations.rs`: widened `migrate_v14`'s `DELETE` target set from `kind = 'annotation_usage'` to `kind IN ('annotation_usage', 'decorator')`. `annotation` is deliberately not added — legitimate direct edges target it (e.g. `@Retention @interface Foo {}`), and `TokenSave::open` already forces a full reindex on any migration, which overwrites stale rows regardless.
- `tests/migration_test.rs`: extended the fixture with a phantom usage-to-decorator row (must be deleted) and a legitimate decorator-as-source row (must survive), proving the delete keys on target kind.
- `CHANGELOG.md`: corrected the now-false claim that "usage-to-declaration edges are unaffected".

## Test plan

- [x] `cargo test` passes (both `--no-default-features --features lite` and full default features; 7 pre-existing sidecar-documentation failures under `lite` confirmed unrelated, reproduced identically on stock `master`)
- [x] `cargo clippy` has no new warnings (`cargo clippy --workspace --all-targets`, `cargo fmt --all -- --check`)
- [x] Tested manually: mutation checks (reverting the resolver allowlist, and narrowing the migration `DELETE` two different ways) confirmed each new test fails exactly as expected and nothing else. End-to-end verification against scratch copies of two real stale v13 databases (this repo's own root DB and a Dart/Flutter corpus) confirmed `user_version` reaches 14, phantom-edge count drops to 0, and legitimate `annotates` target-kind counts are unchanged. A synthetic Python/Java fixture with an intentional cross-language name collision confirmed no `annotates` edge targets a `decorator` or `annotation_usage` node even in that case.

## Checklist

- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [x] No secrets, credentials, or `.env` files included
- [x] Breaking changes documented (if any) — N/A, this is a bug fix; existing databases are repaired in place by migration V14
