### PR TITLE
fix(cli): keep stdout clean on bare invocation for hook contract

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -442,8 +442,13 @@ async fn is_fresh_install() -> bool {
 pub(crate) async fn handle_no_command() -> tokensave::errors::Result<()> {
     let project_path = tokensave::config::resolve_path(None);
     if TokenSave::is_initialized(&project_path) {
-        // Already initialized — show help via clap
-        let _ = <crate::cli::Cli as clap::CommandFactory>::command().print_help();
+        // Already initialized — render help to stderr, never stdout. Agent
+        // permission hooks invoke a bare `tokensave` and parse stdout as JSON;
+        // help text there is a fatal parse error that fail-closes the wrapped
+        // command. An empty stdout with exit 0 reads as "no opinion" instead.
+        // See #347, #348, #351.
+        let mut cmd = <crate::cli::Cli as clap::CommandFactory>::command();
+        eprint!("{}", cmd.render_help());
         eprintln!();
         return Ok(());
     }
@@ -454,6 +459,16 @@ pub(crate) async fn handle_no_command() -> tokensave::errors::Result<()> {
              in your project root."
         );
         eprintln!();
+    }
+    // Never prompt when stdin isn't a terminal. A hook pipes its JSON payload
+    // into a bare `tokensave`; reading it here would consume that payload and
+    // could be mistaken for a "yes", spuriously initializing the project (#351).
+    if !io::stdin().is_terminal() {
+        eprintln!(
+            "No TokenSave index found at '{}'. Run `tokensave init` to create one.",
+            project_path.display()
+        );
+        return Ok(());
     }
     eprint!(
         "No TokenSave index found at '{}'. Create one now? [Y/n] ",

--- a/tests/bare_invocation_stdout_test.rs
+++ b/tests/bare_invocation_stdout_test.rs
@@ -1,0 +1,96 @@
+//! A bare `tokensave` (no subcommand) must keep stdout empty. Agent permission
+//! hooks (Claude Code, Cursor) invoke a bare `tokensave` and parse its stdout
+//! as JSON; any help text there is a fatal parse error that fail-closes the
+//! wrapped command. Help belongs on stderr, and an empty stdout with exit 0
+//! reads as "no opinion". (#347, #348, #351)
+//!
+//! Driven through the real binary because the behaviour lives in the CLI path.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use tempfile::TempDir;
+
+/// A project with a real index in place, so a bare invocation takes the
+/// "already initialized → show help" branch of `handle_no_command`.
+fn initialized_project() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    std::fs::create_dir(dir.path().join("src")).unwrap();
+    std::fs::write(dir.path().join("src/lib.rs"), "pub fn hello() {}\n").unwrap();
+    let status = Command::new(env!("CARGO_BIN_EXE_tokensave"))
+        .arg("init")
+        .arg(dir.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("failed to spawn tokensave init");
+    assert!(status.success(), "init must succeed to set up the fixture");
+    dir
+}
+
+/// Runs a bare `tokensave` in `dir` with `stdin_data` piped (never a TTY under
+/// `cargo test`) and returns stdout and stderr captured separately.
+fn run_bare(dir: &std::path::Path, stdin_data: &str) -> (String, String) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_tokensave"))
+        .current_dir(dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn tokensave");
+    child
+        .stdin
+        .take()
+        .expect("stdin piped")
+        .write_all(stdin_data.as_bytes())
+        .expect("failed to write stdin");
+    let output = child
+        .wait_with_output()
+        .expect("failed to wait for tokensave");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn bare_invocation_in_initialized_project_keeps_stdout_empty() {
+    let dir = initialized_project();
+    // A permission hook pipes its JSON payload into a bare `tokensave`.
+    let (stdout, stderr) = run_bare(dir.path(), "{\"tool\":\"Bash\"}\n");
+
+    assert!(
+        stdout.is_empty(),
+        "bare invocation must write nothing to stdout so hooks can parse it as JSON, got: {stdout:?}"
+    );
+    // Help still belongs somewhere the user can see it — stderr.
+    assert!(
+        stderr.contains("Usage"),
+        "help should be rendered to stderr instead: {stderr:?}"
+    );
+}
+
+#[test]
+fn bare_invocation_uninitialized_with_piped_stdin_does_not_prompt_or_init() {
+    let dir = TempDir::new().unwrap();
+    std::fs::create_dir(dir.path().join("src")).unwrap();
+    std::fs::write(dir.path().join("src/lib.rs"), "pub fn hello() {}\n").unwrap();
+
+    // A piped "y" must not be taken for an interactive answer, so no index is
+    // created and stdout stays clean.
+    let (stdout, stderr) = run_bare(dir.path(), "y\n");
+
+    assert!(
+        stdout.is_empty(),
+        "bare invocation must write nothing to stdout, got: {stdout:?}"
+    );
+    assert!(
+        !stderr.contains("Create one now?"),
+        "a non-interactive bare invocation must not prompt: {stderr:?}"
+    );
+    assert!(
+        !dir.path().join(".tokensave").exists(),
+        "the piped 'y' must not be taken as consent to initialize"
+    );
+}


### PR DESCRIPTION
## Summary

A bare `tokensave` (no subcommand) in an initialized project rendered clap's help to **stdout** via `print_help()` and exited 0. Agent permission hooks (Claude Code, Cursor) invoke a bare `tokensave` and parse its stdout as JSON — the help text is a fatal parse error that fail-closes the wrapped Shell command.

## Changes

- `handle_no_command`: render help to **stderr** (`render_help()`), leaving stdout empty. Exit 0 with empty stdout reads as "no opinion" to a permission hook.
- Guard the uninitialized `Create one now? [Y/n]` prompt behind `io::stdin().is_terminal()`, so a hook's piped JSON payload is neither consumed nor mistaken for a "yes" (the piped-stdin half of #351). Mirrors the existing `init` prompt guard from #288.
- Adds `tests/bare_invocation_stdout_test.rs` — asserts stdout stays empty on a bare invocation (initialized → help to stderr; uninitialized + piped stdin → no prompt, no init).

## Testing

- `cargo test --test bare_invocation_stdout_test` — 2 passed (RED before the fix, GREEN after)
- `cargo fmt --check` clean, `cargo clippy --tests` clean

Closes #351
Closes #348
Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1EVaNnJTQbj6zSnGXE1KB