### PR TITLE
fix(dead-code): exempt Go `init` from dead-code false positives

### DIFF
--- a/src/graph/queries.rs
+++ b/src/graph/queries.rs
@@ -267,6 +267,12 @@ impl<'a> GraphQueryManager<'a> {
              WHERE name != 'main'
              AND name != '_bind_methods'
              AND name NOT LIKE 'test%'
+             -- Go package-level `init` is invoked implicitly by the runtime at
+             -- package load and can never be called explicitly, so it carries
+             -- no incoming `calls` edge — the same reason `main`, `test*`, and
+             -- Rust trait-impl methods are exempt. Scoped to `.go` so a callable
+             -- function named `init` in another language is still checked (#346).
+             AND NOT (name = 'init' AND file_path LIKE '%.go')
              {visibility_filter}
              {kind_filter}
              {trait_impl_filter}

--- a/tests/go_init_dead_code_test.rs
+++ b/tests/go_init_dead_code_test.rs
@@ -1,0 +1,84 @@
+//! Regression test for #346 (part 2a): Go `func init()` must not be reported
+//! as dead code.
+//!
+//! A package-level `init` in Go is invoked implicitly by the runtime at package
+//! initialization and can never be called explicitly — exactly like the Rust
+//! trait-impl methods (#137), the Godot `_bind_methods` callback (#269), and
+//! `main`, all of which the dead-code query already exempts. Without the
+//! exemption, every `init` in a Go codebase is a false positive (21 of 33
+//! flags in the issue's sample were `init`).
+//!
+//! The exemption must stay narrow: a genuinely unreferenced Go function is
+//! still dead code and must still be reported.
+
+use std::fs;
+
+use tempfile::TempDir;
+use tokensave::tokensave::TokenSave;
+
+/// A Go module with an implicitly-invoked `init`, a genuinely dead helper, and
+/// a live function reached from `init`, so the test can prove the exemption is
+/// scoped to `init` and does not suppress real dead code.
+async fn setup() -> (TokenSave, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    fs::write(project.join("go.mod"), "module example.com/u\n\ngo 1.22\n").unwrap();
+    fs::write(
+        project.join("main.go"),
+        r#"
+package main
+
+import "fmt"
+
+var registry = map[string]int{}
+
+// init is runtime-dispatched at package load; it has no explicit caller.
+func init() {
+    registry["seed"] = seedValue()
+}
+
+// seedValue is reached only from init — it is alive.
+func seedValue() int {
+    return 42
+}
+
+// unusedHelper is referenced by nothing; it is genuinely dead.
+func unusedHelper() int {
+    return 7
+}
+
+func main() {
+    fmt.Println(registry)
+}
+"#,
+    )
+    .unwrap();
+
+    let cg = TokenSave::init(project).await.unwrap();
+    cg.index_all().await.unwrap();
+    (cg, dir)
+}
+
+#[tokio::test]
+async fn go_init_is_not_reported_dead() {
+    let (cg, _dir) = setup().await;
+    // include_public=true stresses the analysis; `init` is unexported (private)
+    // but must be exempt regardless of the visibility filter.
+    let dead = cg.find_dead_code(&[], true, false).await.unwrap();
+    let dead_names: Vec<&str> = dead.iter().map(|n| n.name.as_str()).collect();
+
+    assert!(
+        !dead_names.contains(&"init"),
+        "Go `init` is runtime-dispatched and must not be dead code, got {dead_names:?}"
+    );
+    // seedValue is called from init, so it must not be dead either.
+    assert!(
+        !dead_names.contains(&"seedValue"),
+        "seedValue is called from init and must not be dead code, got {dead_names:?}"
+    );
+    // The exemption must not swallow real dead code.
+    assert!(
+        dead_names.contains(&"unusedHelper"),
+        "an unreferenced Go function must still be reported dead, got {dead_names:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Partial fix for #346. Go package-level `func init()` is invoked implicitly by the runtime at package load and can never be called explicitly, so it never carries an incoming `calls` edge — and `find_dead_code` flagged every one as dead. **21 of the 33 flags** in #346's Go sample were `init`.

This is the same class already handled for `main`, `test*`, Godot `_bind_methods` (#269), and Rust trait-impl methods (#137). The fix just adds `init` to that existing exclusion list.

## Change

One clause in the dead-code query:

```sql
AND NOT (name = 'init' AND file_path LIKE '%.go')
```

Scoped to `.go` so a callable function named `init` in another language is still checked, and a genuinely unreferenced Go function is still reported dead.

## Testing

`tests/go_init_dead_code_test.rs` — indexes a Go module with an implicit `init`, a live function reached from `init`, and a genuinely dead helper. Asserts `init`/`seedValue` are spared **and** `unusedHelper` is still flagged (proving the exemption stays narrow). RED before the change, GREEN after. `go_bug148`, `godot_bind_methods`, and `graph` suites still pass; fmt + clippy clean.

## Not covered here (still open under #346)

These are separate edge-resolution gaps, not entry-point exclusions, and need deeper work (and ideally the reporter's polyglot repo to verify):
- the fabricated cross-language strongly-connected component in `tokensave_circular`
- build-tag-conditional callers (`//go:build …`)
- function-value assignments (`var F = fn`) counted as a use
- same-file / same-closure calls being missed (Go test-file same-package, TS Pinia setup closures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1EVaNnJTQbj6zSnGXE1KB