### PR TITLE
docs(security): SECURITY.md understates what the database retains (#377)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project uses [maintenance-based versioning](TOKENSAVE-VERSIONING.md), n
 
 ## [Unreleased]
 
+### Documentation
+- **SECURITY.md described the database as structural metadata only, which understated what it retains (#377).** The policy named `read_cache` as the sole place source text is kept, but `executable_body_fts` is declared without `content=''`, so FTS5 retains the original text of every column in `executable_body_fts_content` — including `body`, which holds complete function bodies. The enumeration above the sentence said "FTS5 search index", which does not tell a reader that full source is retained. Corrected in three places: the storage list, the sentence that follows it, and the Best Practices note, which likewise mentioned only symbol names and `read_cache`. No storage change is involved: the bodies are load-bearing for `tokensave_context`, and a contentless table would return NULL for `SELECT node_id, body`. The "Supported Versions" table, still listing 6.x as current, is updated to 7.x in the same pass.
+
 ## [7.9.0] - 2026-08-08
 
 ### Added

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,8 +15,8 @@ Only the current major release line is supported. All minor and patch versions w
 
 | Version | Supported |
 |---------|-----------|
-| 6.x (current) | Yes — all minor and patch releases |
-| < 6 | No |
+| 7.x (current) | Yes — all minor and patch releases |
+| < 7 | No |
 
 **No vulnerabilities have been reported or discovered to date.**
 
@@ -31,11 +31,11 @@ tokensave builds a **local** code graph stored in a SQLite (libSQL) database (`.
 - Symbol names, signatures, and docstrings
 - File paths, sizes, and content hashes
 - Call relationships and dependency edges
-- FTS5 search index
+- FTS5 search index (`executable_body_fts`): the `body` column retains the complete text of every indexed function body
 - Cross-session memory (recorded decisions and code-area notes)
 - A response cache for `tokensave_read` (`read_cache` table): the rendered output served to the agent, stored as a BLOB keyed by file path, mode, and arguments. For full/line-range reads this rendered output contains source text. Rows are freshness-gated by file mtime and swept after a period of inactivity.
 
-Aside from the `read_cache`, the graph itself does **not** persist raw source code — it stores structural metadata only. The database is local-only — there is no cloud sync, remote database, or server-side storage.
+The database stores structural metadata, plus source text in two places: the `read_cache` table, and the `executable_body_fts` full-text index, whose `body` column retains complete function bodies. Treat `.tokensave/tokensave.db` as containing your source code, and keep it out of version control. The database is local-only — there is no cloud sync, remote database, or server-side storage.
 
 A second database (`~/.tokensave/global.db`) tracks which projects have been indexed, aggregate token-saved counts, and cost accounting data parsed from Claude Code session transcripts. It contains directory paths, counters, per-turn cost/token/category records, and JSONL parse offsets. No source code or conversation content is stored.
 
@@ -114,7 +114,7 @@ The Windows-elevation `unsafe` documented in earlier versions was removed alongs
 ## Best Practices
 
 - Add `.tokensave/` to your `.gitignore` to avoid committing the local database.
-- If your project contains sensitive code, be aware that the database stores symbol names and signatures, and the `read_cache` table can hold rendered source text from `tokensave_read` responses. Adding `.tokensave/` to `.gitignore` keeps both out of version control.
+- If your project contains sensitive code, be aware that the database stores symbol names and signatures, that the `executable_body_fts` index retains complete function bodies, and that the `read_cache` table can hold rendered source text from `tokensave_read` responses. Adding `.tokensave/` to `.gitignore` keeps all three out of version control.
 - Keep tokensave updated (`tokensave upgrade`) to receive security fixes.
 - Review the [CHANGELOG](CHANGELOG.md) before upgrading to understand what changed.
 


### PR DESCRIPTION
## Summary

- Corrects `SECURITY.md` in three places where the database is described as retaining no raw source code, when `executable_body_fts` retains complete function bodies
- Updates the "Supported Versions" table from 6.x to 7.x
- Documentation only; no code, no schema, no behaviour change

## Motivation

Closes #377.

The policy sentence at `SECURITY.md:38` named `read_cache` as the only place source text is kept. `executable_body_fts` is declared without `content=''`, so FTS5 retains the original text of every column in its shadow table `executable_body_fts_content`, `body` included. On the index I measured, `read_cache` held 0 rows while the FTS content table held 779 function bodies, so the exception the policy named was empty and the table it called structural metadata held all the source text.

The enumeration above that sentence does say "FTS5 search index", so nothing was concealed. The problem is that the phrase does not tell a reader full source is retained, which is the decision the section is there to inform.

## Changes

- `SECURITY.md:34` — the storage list entry now names `executable_body_fts` and says the `body` column retains complete function bodies. This is the phrase a reader scans first, so leaving it as "FTS5 search index" would keep the gap open even with the sentence below corrected.
- `SECURITY.md:38` — rewritten to your wording in #377.
- `SECURITY.md:117` — the Best Practices note mentioned only symbol names, signatures, and `read_cache`. Now names all three stores, and "keeps both" becomes "keeps all three".
- `SECURITY.md:18-19` — Supported Versions 6.x → 7.x. Current release is 7.9.0.
- `CHANGELOG.md` — entry under `[Unreleased]`, in a `### Documentation` section.

The `SECURITY.md:34` change is the one item not asked for in #377. Say the word and I will drop it; the rest stand on their own.

## Test plan

- [ ] `cargo test` passes
- [ ] `cargo clippy` has no new warnings
- [x] Tested manually

No Rust toolchain on this machine, so I have not run `cargo test` or `cargo clippy`. The PR touches two Markdown files and no code, so neither should have anything to say about it, but I would rather state that than tick boxes I did not check.

What I did verify, against `master` at the time of writing:

- `executable_body_fts` is declared without `content=''`, on an index created with 7.9.0 in an empty repo
- `executable_body_fts_content` holds `node_id`, `file_path`, and `body` verbatim, UNINDEXED columns included
- a contentless FTS5 table returns NULL for both columns of `SELECT node_id, body`, which is why no storage change is proposed
- current release is 7.9.0, so the version table 