### PR TITLE
feat(indexing): warn when tracked files in hidden directories are skipped (#355)

### DIFF
--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -184,6 +184,21 @@ rules, set `exclude` globs in `.tokensave/config.json`:
 
 `tokensave init --skip-folder <dir>` writes to that same list.
 
+#### Indexing hidden directories
+
+By default, tokensave prunes all hidden directories (dot-prefixed) during the file walk to avoid indexing massive dependency and config folders (like `.venv`, `.cargo`, or `.next`).
+
+If your project contains code in hidden directories (e.g., `.github/scripts/`), you must explicitly opt-in via the `include` array in `.tokensave/config.json`. **Crucially, you must include both the directory and its contents**, because the walker prunes at the directory level before glob matching happens:
+
+```json
+{
+  "include": [
+    ".github",
+    ".github/**"
+  ]
+}
+```
+
 ---
 
 ## Connecting to Your Agent

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -584,6 +584,9 @@ pub(crate) async fn init_and_index(
         // compact headline (and its "rerun with --verbose" hint) would repeat it.
         print_skipped_extension_summary(&result.skipped_extensions);
     }
+    if let Some(warning) = cg.warn_skipped_hidden_dirs() {
+        eprintln!("{warning}");
+    }
     global::update_global_db(&cg).await;
     Ok(cg)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -418,6 +418,9 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
                     result.files_removed,
                     result.duration_ms
                 ));
+                if let Some(warning) = cg.warn_skipped_hidden_dirs() {
+                    eprintln!("{warning}");
+                }
                 if !result.skipped_paths.is_empty() {
                     eprintln!();
                     eprintln!(

--- a/src/tokensave/indexing.rs
+++ b/src/tokensave/indexing.rs
@@ -1147,6 +1147,16 @@ impl TokenSave {
         crate::project_manifest::manifest_for(&self.project_root, &self.registry)
     }
 
+    /// Returns a warning message if git-tracked files in hidden directories were skipped by indexing.
+    pub fn warn_skipped_hidden_dirs(&self) -> Option<String> {
+        detect_skipped_hidden_dirs(
+            &self.project_root,
+            &self.config,
+            self.manifest().as_deref(),
+            &self.registry.supported_extensions(),
+        )
+    }
+
     pub(crate) fn scan_files(&self) -> Vec<String> {
         self.scan_files_diagnostics().0
     }
@@ -1444,7 +1454,123 @@ impl TokenSave {
         }
         Some(rel_str)
     }
+}
 
+/// Detects git-tracked, indexable files that the hidden-directory filter
+/// skipped. Returns a formatted warning string if any exist.
+///
+/// Mirrors the walker's pruning rule exactly (`scan_files_walkdir` /
+/// `scan_files_with_gitignore`): a dot-prefixed *directory* blocks descent
+/// unless that directory path itself matches an include glob or manifest
+/// entry. Matching only the files inside (e.g. `.github/**` without a bare
+/// `.github` entry) does not re-enable descent, so this check walks each
+/// ancestor prefix the same way the walker does instead of testing the file
+/// path — otherwise the warning would go silent in exactly that trap.
+pub fn detect_skipped_hidden_dirs(
+    project_root: &Path,
+    config: &TokenSaveConfig,
+    manifest: Option<&crate::project_manifest::CompiledManifest>,
+    supported_exts: &[&str],
+) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        // -z: NUL-separated output, no C-quoting of non-ASCII paths.
+        .args(["ls-files", "-z"])
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut dir_counts: HashMap<String, usize> = HashMap::new();
+    // Sibling files share the same verdict, so evaluate the globs once per
+    // parent directory instead of once per file. `Some(prefix)` = the hidden
+    // ancestor the walker would prune at; `None` = reachable or deliberately
+    // excluded.
+    let mut dir_cache: HashMap<String, Option<String>> = HashMap::new();
+
+    for rel_path in stdout.split('\0') {
+        // Only count files an extractor could actually index; otherwise every
+        // repo with a tracked `.github/workflows/*.yml` would warn.
+        let ext = Path::new(rel_path)
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("");
+        if !supported_exts.contains(&ext) {
+            continue;
+        }
+        // File-level excludes are a deliberate opt-out; including the dir
+        // would not index these files, so warning about them is a false
+        // promise.
+        if is_excluded(rel_path, config) {
+            continue;
+        }
+        // Root-level dotfiles have no hidden ancestor directory.
+        let Some((dirs, _file)) = rel_path.rsplit_once('/') else {
+            continue;
+        };
+
+        let blocked = dir_cache.entry(dirs.to_string()).or_insert_with(|| {
+            // Apply the walker's hidden-directory test at each ancestor prefix.
+            let mut end = 0;
+            for comp in dirs.split('/') {
+                end += comp.len() + usize::from(end > 0);
+                if !comp.starts_with('.') {
+                    continue;
+                }
+                let prefix = &dirs[..end];
+                // Explicitly excluded dirs are a deliberate opt-out, not a trap.
+                if is_excluded_dir(prefix, config) {
+                    return None;
+                }
+                let allowed = is_included(prefix, config)
+                    || manifest.is_some_and(|m| {
+                        m.matches_local_file(prefix) || m.local_dir_may_contain(prefix)
+                    });
+                if !allowed {
+                    return Some(prefix.to_string());
+                }
+            }
+            None
+        });
+        if let Some(prefix) = blocked {
+            // `git ls-files` lists index entries that may not exist on disk
+            // (sparse checkouts, deletions staged but not committed); the
+            // walker never would have seen those, so don't warn about them.
+            if !project_root.join(rel_path).is_file() {
+                continue;
+            }
+            *dir_counts.entry(prefix.clone()).or_insert(0) += 1;
+        }
+    }
+
+    if dir_counts.is_empty() {
+        return None;
+    }
+
+    let total: usize = dir_counts.values().sum();
+    let mut dir_vec: Vec<(String, usize)> = dir_counts.into_iter().collect();
+    dir_vec.sort_unstable_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+
+    let dir_summary = dir_vec
+        .iter()
+        .map(|(dir, count)| format!("{dir}: {count}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let top_dir = &dir_vec[0].0;
+    let file_word = if total == 1 { "file" } else { "files" };
+
+    Some(format!(
+        "\x1b[33mwarning:\x1b[0m skipped {total} tracked {file_word} in hidden directories ({dir_summary}) — add \"{top_dir}\" and \"{top_dir}/**\" to include[] in .tokensave/config.json, then run `tokensave sync -f` to index them (or add \"{top_dir}/**\" to exclude[] to silence this warning)"
+    ))
+}
+
+impl TokenSave {
     /// Returns the artifact extensions actually in effect for this project.
     ///
     /// An extension a language extractor already handles is dropped: the symbol

--- a/src/tokensave/mod.rs
+++ b/src/tokensave/mod.rs
@@ -32,6 +32,7 @@ mod util;
 pub(crate) use extract::*;
 pub(crate) use guard::*;
 pub use guard::{try_acquire_sync_lock, SyncLockGuard};
+pub use indexing::detect_skipped_hidden_dirs;
 pub use util::is_test_file;
 pub(crate) use util::*;
 

--- a/tests/warn_skipped_hidden_dirs_test.rs
+++ b/tests/warn_skipped_hidden_dirs_test.rs
@@ -1,0 +1,153 @@
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+use tokensave::config::TokenSaveConfig;
+use tokensave::tokensave::detect_skipped_hidden_dirs;
+
+const EXTS: &[&str] = &["py"];
+
+fn git(root: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .status()
+        .unwrap_or_else(|e| panic!("git {args:?} failed to spawn: {e}"));
+    assert!(status.success(), "git {args:?} failed");
+}
+
+fn setup_repo() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    git(root, &["init", "-q"]);
+
+    let scripts = root.join(".github").join("scripts");
+    std::fs::create_dir_all(&scripts).unwrap();
+    std::fs::write(scripts.join("deploy.py"), "print('deploy')\n").unwrap();
+    // Untracked hidden file: must not be counted.
+    std::fs::write(scripts.join("untracked.py"), "print('untracked')\n").unwrap();
+    git(root, &["add", ".github/scripts/deploy.py"]);
+    dir
+}
+
+#[test]
+fn warns_for_tracked_hidden_file_and_ignores_untracked() {
+    let dir = setup_repo();
+    let config = TokenSaveConfig::default();
+
+    let warn = detect_skipped_hidden_dirs(dir.path(), &config, None, EXTS)
+        .expect("expected warning for git-tracked file under .github/");
+    assert!(
+        warn.contains("skipped 1 tracked file in hidden directories (.github: 1)"),
+        "warning should count only the tracked file: {warn}"
+    );
+    assert!(
+        warn.contains("\".github\" and \".github/**\""),
+        "warning should suggest both include entries: {warn}"
+    );
+}
+
+#[test]
+fn glob_only_include_does_not_silence_warning() {
+    // The walker prunes on the bare directory entry, so `.github/**` alone
+    // does not re-enable descent — the warning must persist to flag the trap.
+    let dir = setup_repo();
+    let mut config = TokenSaveConfig::default();
+    config.include.push(".github/**".to_string());
+
+    assert!(
+        detect_skipped_hidden_dirs(dir.path(), &config, None, EXTS).is_some(),
+        "include of only \".github/**\" must not suppress the warning"
+    );
+}
+
+#[test]
+fn full_include_suppresses_warning() {
+    let dir = setup_repo();
+    let mut config = TokenSaveConfig::default();
+    config.include.push(".github".to_string());
+    config.include.push(".github/**".to_string());
+
+    assert!(
+        detect_skipped_hidden_dirs(dir.path(), &config, None, EXTS).is_none(),
+        "warning should be suppressed when the directory is included"
+    );
+}
+
+#[test]
+fn excluded_dir_suppresses_warning() {
+    let dir = setup_repo();
+    let mut config = TokenSaveConfig::default();
+    config.exclude.push(".github/**".to_string());
+
+    assert!(
+        detect_skipped_hidden_dirs(dir.path(), &config, None, EXTS).is_none(),
+        "explicitly excluded dirs are a deliberate opt-out, not a trap"
+    );
+}
+
+#[test]
+fn unsupported_extensions_are_not_counted() {
+    let dir = setup_repo();
+    let root = dir.path();
+    let workflows = root.join(".github").join("workflows");
+    std::fs::create_dir_all(&workflows).unwrap();
+    std::fs::write(workflows.join("ci.yml"), "on: push\n").unwrap();
+    git(root, &["add", ".github/workflows/ci.yml"]);
+
+    let config = TokenSaveConfig::default();
+    let warn = detect_skipped_hidden_dirs(root, &config, None, EXTS).unwrap();
+    assert!(
+        warn.contains("(.github: 1)"),
+        "the tracked .yml must not be counted alongside the .py: {warn}"
+    );
+}
+
+#[test]
+fn nested_hidden_dir_is_reported_with_full_prefix() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    git(root, &["init", "-q"]);
+    let hidden = root.join("src").join(".hidden");
+    std::fs::create_dir_all(&hidden).unwrap();
+    std::fs::write(hidden.join("a.py"), "x = 1\n").unwrap();
+    git(root, &["add", "src/.hidden/a.py"]);
+
+    let config = TokenSaveConfig::default();
+    let warn = detect_skipped_hidden_dirs(root, &config, None, EXTS).unwrap();
+    assert!(
+        warn.contains("(src/.hidden: 1)") && warn.contains("\"src/.hidden\""),
+        "nested hidden dirs should be reported with the exact prefix to include: {warn}"
+    );
+}
+
+#[test]
+fn missing_on_disk_tracked_file_is_not_counted() {
+    // Sparse checkouts and staged deletions keep index entries for files the
+    // walker never would have seen; they must not trigger the warning.
+    let dir = setup_repo();
+    std::fs::remove_file(dir.path().join(".github/scripts/deploy.py")).unwrap();
+    let config = TokenSaveConfig::default();
+    assert!(
+        detect_skipped_hidden_dirs(dir.path(), &config, None, EXTS).is_none(),
+        "index entries missing from disk must not warn"
+    );
+}
+
+#[test]
+fn file_level_exclude_suppresses_warning() {
+    let dir = setup_repo();
+    let mut config = TokenSaveConfig::default();
+    config.exclude.push("**/deploy.py".to_string());
+    assert!(
+        detect_skipped_hidden_dirs(dir.path(), &config, None, EXTS).is_none(),
+        "file-level excludes are a deliberate opt-out"
+    );
+}
+
+#[test]
+fn non_git_directory_returns_none() {
+    let dir = TempDir::new().unwrap();
+    let config = TokenSaveConfig::default();
+    assert!(detect_skipped_hidden_dirs(dir.path(), &config, None, EXTS).is_none());
+}


### PR DESCRIPTION
Follow-up to #355. You kept skip-hidden-by-default (which this PR does not touch) — this addresses only the other half of that report: the *silence*. Feel free to close if a sync-time notice isn't something you want; no hard feelings.

## Change
After `init`/`sync`, one batched `git ls-files -z` is compared against the walker's own pruning predicate, and if git-tracked, extractor-indexable files were skipped solely by the hidden-directory filter, a single aggregated line is printed:

```
warning: skipped 87 tracked files in hidden directories (.github: 87) — add ".github" and ".github/**" to include[] in .tokensave/config.json, then run `tokensave sync -f` to index them (or add ".github/**" to exclude[] to silence this warning)
```

- **No change to what gets indexed** — the `include[]` opt-in you described stays the only remedy, and the warning teaches exactly it (both entries + `sync -f`).
- **No new dependencies**; non-git projects and git failures are silently ignored.

## Design notes
- The suppression check mirrors the walker's per-ancestor directory predicate rather than glob-matching file paths, so a partial config (`.github/**` without the bare `.github`) keeps warning until the config actually works — the exact trap you flagged in #355.
- Only files with extensions a registered extractor supports count, so `.github/workflows/*.yml` alone never warns.
- `exclude[]`-covered dirs/files are deliberate opt-outs (no warning); index entries missing on disk (sparse checkouts, staged deletions) are ignored.

## Test
`tests/warn_skipped_hidden_dirs_test.rs` — 9 cases: tracked/untracked, partial-include trap, full include, dir- and file-level excludes, unsupported extensions, nested hidden dirs, sparse/missing-on-disk, non-git. Verified locally against master (1f11c05) on Rust 1.95.0: 9/9 pass, fmt/clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
