### PR TITLE
fix(tests): isolate fixtures from global git hooks

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,6 +6,16 @@
 CFLAGS = { value = "-DNDEBUG", force = false }
 CXXFLAGS = { value = "-DNDEBUG", force = false }
 
+# Test fixtures create real Git repositories and must not inherit developer
+# hooks such as the global hooks installed by `tokensave install` (#381).
+# This command-scope Git setting is inherited by every Git child process while
+# preserving an explicitly supplied GIT_CONFIG_* environment (`force = false`).
+# A caller-provided indexed Git config can occupy slot 0 and disable this
+# isolation; the regression test then exposes the inherited hook.
+GIT_CONFIG_COUNT = { value = "1", force = false }
+GIT_CONFIG_KEY_0 = { value = "core.hooksPath", force = false }
+GIT_CONFIG_VALUE_0 = { value = "", force = false }
+
 # Raise the main-thread stack reserve to 8 MB on Windows MSVC.  RUST_MIN_STACK
 # (set in CI) only resizes threads Rust spawns; the main thread's stack is fixed
 # at link time and defaults to ~1 MB on MSVC, versus ~8 MB on Linux/macOS.  A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project uses [maintenance-based versioning](TOKENSAVE-VERSIONING.md), n
 
 ## [Unreleased]
 
+### Fixed
+- **Cargo-driven tests no longer inherit developer-level Git hooks (#381).** A developer who had run `tokensave install` also had a global `core.hooksPath`, so real Git operations inside temporary test repositories executed TokenSave's background `post-commit` and `post-checkout` hooks. Those hooks raced the fixture itself, intermittently taking its sync lock or modifying `.tokensave/` while assertions were running. Cargo now supplies an empty command-scope `core.hooksPath` to the processes Cargo launches, while leaving the developer's global Git configuration unchanged.
+
 ### Documentation
 - **SECURITY.md described the database as structural metadata only, which understated what it retains (#377).** The policy named `read_cache` as the sole place source text is kept, but `executable_body_fts` is declared without `content=''`, so FTS5 retains the original text of every column in `executable_body_fts_content` — including `body`, which holds complete function bodies. The enumeration above the sentence said "FTS5 search index", which does not tell a reader that full source is retained. Corrected in three places: the storage list, the sentence that follows it, and the Best Practices note, which likewise mentioned only symbol names and `read_cache`. No storage change is involved: the bodies are load-bearing for `tokensave_context`, and a contentless table would return NULL for `SELECT node_id, body`. The "Supported Versions" table, still listing 6.x as current, is updated to 7.x in the same pass.
 

--- a/tests/git_hook_isolation_test.rs
+++ b/tests/git_hook_isolation_test.rs
@@ -1,0 +1,102 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+fn run_git(root: &Path, global_config: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        // The fixture must exercise a controlled global Git configuration,
+        // independently of the developer's real home directory.
+        .env("GIT_CONFIG_GLOBAL", global_config)
+        .env("GIT_AUTHOR_NAME", "TokenSave Test")
+        .env("GIT_AUTHOR_EMAIL", "tokensave@example.com")
+        .env("GIT_COMMITTER_NAME", "TokenSave Test")
+        .env("GIT_COMMITTER_EMAIL", "tokensave@example.com")
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn commit(
+    project: &Path,
+    global_config: &Path,
+    marker: &Path,
+    message: &str,
+    restore_global_hooks: bool,
+) {
+    let mut command = Command::new("git");
+    command
+        .args(["commit", "--allow-empty", "-m", message])
+        .current_dir(project)
+        .env("GIT_CONFIG_GLOBAL", global_config)
+        .env("GIT_AUTHOR_NAME", "TokenSave Test")
+        .env("GIT_AUTHOR_EMAIL", "tokensave@example.com")
+        .env("GIT_COMMITTER_NAME", "TokenSave Test")
+        .env("GIT_COMMITTER_EMAIL", "tokensave@example.com")
+        .env("TOKENSAVE_TEST_HOOK_MARKER", marker);
+    if restore_global_hooks {
+        // Cancel the command-scope core.hooksPath supplied by Cargo so the
+        // controlled global hooks path applies for the positive control.
+        command.env("GIT_CONFIG_COUNT", "0");
+    }
+    let output = command.output().expect("commit fixture");
+    assert!(
+        output.status.success(),
+        "git commit failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn cargo_test_disables_global_git_hooks_in_fixtures() {
+    let sandbox = tempfile::tempdir().expect("tempdir");
+    let project = sandbox.path().join("project");
+    let hooks = sandbox.path().join("hooks");
+    let global_config = sandbox.path().join("gitconfig");
+    let marker = sandbox.path().join("hook-fired");
+    fs::create_dir_all(&project).expect("create project");
+    fs::create_dir_all(&hooks).expect("create hooks");
+
+    let hook = hooks.join("post-commit");
+    fs::write(
+        &hook,
+        "#!/bin/sh\nprintf fired > \"$TOKENSAVE_TEST_HOOK_MARKER\"\n",
+    )
+    .expect("write hook");
+    #[cfg(unix)]
+    fs::set_permissions(&hook, fs::Permissions::from_mode(0o755)).expect("chmod hook");
+
+    let config_output = Command::new("git")
+        .args(["config", "--file"])
+        .arg(&global_config)
+        .arg("core.hooksPath")
+        .arg(&hooks)
+        .output()
+        .expect("write controlled global config");
+    assert!(config_output.status.success());
+
+    run_git(&project, &global_config, &["init", "-b", "master"]);
+
+    commit(&project, &global_config, &marker, "positive control", true);
+    assert!(
+        marker.exists(),
+        "controlled post-commit hook did not run; this test cannot verify Cargo hook isolation"
+    );
+    fs::remove_file(&marker).expect("remove positive-control marker");
+
+    commit(&project, &global_config, &marker, "isolated fixture", false);
+
+    assert!(
+        !marker.exists(),
+        "developer-level post-commit hook ran inside a test fixture"
+    );
+}


### PR DESCRIPTION
## Summary

- Prevent Cargo-driven test fixtures from inheriting developer-level global Git hooks.
- Add a self-validating regression test using a real `post-commit` hook.
- Document the fix under `[Unreleased]`.

## Motivation

Fixes #381.

`tokensave install` can configure a global `core.hooksPath`. Because that setting
applies to every repository, TokenSave's background `post-commit` and
`post-checkout` hooks also ran inside temporary repositories created by the test
suite. They raced the fixtures, intermittently taking their sync locks or modifying
their `.tokensave/` directories.

Three full runs in the reported environment produced 7, 3, and 4 failures.
@rscorer independently reproduced the failure by enabling the installed global
hooks path and confirmed that disabling it made the affected test pass.

## Changes

The existing `[env]` block in `.cargo/config.toml` now supplies one
command-scope Git setting to processes launched by Cargo:

```toml
GIT_CONFIG_COUNT = { value = "1", force = false }
GIT_CONFIG_KEY_0 = { value = "core.hooksPath", force = false }
GIT_CONFIG_VALUE_0 = { value = "", force = false }
```

An empty `core.hooksPath` makes Git use the fixture repository's own
`.git/hooks`, which contains only the inert sample files created by `git init`.

The issue proposed passing the same setting with `-c core.hooksPath=` at each
Git invocation. It also identified 26 call sites across four test files, through
six helper definitions plus inline commands. Supplying it once through Cargo
covers those existing paths and future Git child processes without modifying
each call site. The setting is unchanged; only its delivery moves from individual
arguments to the existing Cargo environment layer.

This environment also reaches binaries started with `cargo run`. A binary invoked
directly from `target/` does not inherit it.

Each entry uses `force = false`, so caller-provided indexed `GIT_CONFIG_*` values
take precedence. A caller-provided configuration can therefore occupy slot `0`
and leave this isolation inactive. If the controlled global hook remains active,
the regression test fails instead of silently passing.

The regression test commits twice:

1. It sets `GIT_CONFIG_COUNT=0`, confirms that the controlled global
   `post-commit` hook runs, and removes its marker.
2. It commits with the Cargo-provided isolation and confirms that the marker is
   not recreated.

Only `post-commit` is exercised. The `core.hooksPath` setting itself is
hook-type agnostic.

This PR does not change whether `tokensave branch add` or `tokensave sync`
should operate inside temporary directories.

## Test plan

- [x] `cargo test --no-fail-fast`: 3,221 passed, 0 failed locally on macOS
      across 124 test binaries plus doc-tests.
- [x] Neutralizing the isolation with `GIT_CONFIG_COUNT=0` fails at the
      negative assertion.
- [x] Removing the hook's executable permission fails at the positive-control
      assertion.
- [x] Fork CI test matrix passed on commit `95fe4bb`:

| Runner | Passed | Failed |
| --- | ---: | ---: |
| `ubuntu-latest` | 3,221 | 0 |
| `macos-14` | 3,221 | 0 |
| `windows-latest` | 3,169 | 0 |

The different Windows total comes from existing platform-gated tests. The new
regression test ran and passed on all three runners. The separate Format and
Clippy jobs also passed.

- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `git diff --check`
- [x] Tested manually through both regression-test mutation cases above.

## Checklist

- [x] `CHANGELOG.md` updated under `[Unreleased]`.
- [x] No secrets, credentials, or `.env` files included.
- [x] Breaking changes documented: none.
