### PR TITLE
fix(extraction): extract symbols inside preprocessor conditionals

### DIFF
--- a/src/extraction/c_extractor.rs
+++ b/src/extraction/c_extractor.rs
@@ -113,6 +113,14 @@ impl CExtractor {
             "enum_specifier" => Self::visit_standalone_enum(state, node),
             "preproc_def" => Self::visit_preproc_def(state, node),
             "preproc_include" => Self::visit_preproc_include(state, node),
+            // A conditional block carries no symbol itself, but its body does.
+            // Without this every declaration inside an `#if` / `#ifdef` is
+            // invisible -- which silently drops whole files: the `#ifndef FOO_H`
+            // include-guard idiom wraps an entire header. Both arms of an
+            // `#if/#else` are extracted: deciding which one compiles needs a
+            // preprocessor, and dropping both is strictly worse.
+            "preproc_if" | "preproc_ifdef" | "preproc_else" | "preproc_elif"
+            | "preproc_elifdef" => Self::visit_children(state, node),
             _ => {
                 // For other node types, skip. Comments are picked up as docstrings.
             }

--- a/src/extraction/cpp_extractor.rs
+++ b/src/extraction/cpp_extractor.rs
@@ -186,6 +186,16 @@ impl CppExtractor {
             // `declaration_list` before dispatch, so this can't double-visit
             // them.
             "linkage_specification" | "declaration_list" => Self::visit_children(state, node),
+            // A conditional block carries no symbol itself, but its body does.
+            // Without this every declaration inside an `#if` / `#ifdef` is
+            // invisible -- which silently drops whole files: the `#ifndef FOO_H`
+            // include-guard idiom wraps an entire header, and build-config
+            // guards (`#if !NDEBUG` and friends) wrap entire .cpp files.
+            // Both arms of an `#if/#else` are extracted: deciding which one
+            // compiles needs a preprocessor, and dropping both is strictly
+            // worse than reporting a symbol that some configuration excludes.
+            "preproc_if" | "preproc_ifdef" | "preproc_else" | "preproc_elif"
+            | "preproc_elifdef" => Self::visit_children(state, node),
             _ => {
                 // For other node types, skip. Comments are picked up as docstrings.
             }

--- a/src/extraction/objc_extractor.rs
+++ b/src/extraction/objc_extractor.rs
@@ -107,6 +107,14 @@ impl ObjcExtractor {
         match node.kind() {
             "preproc_include" => Self::visit_preproc_include(state, node),
             "preproc_def" => Self::visit_preproc_def(state, node),
+            // A conditional block carries no symbol itself, but its body does.
+            // Without this every declaration inside an `#if` / `#ifdef` is
+            // invisible -- which silently drops whole files: the `#ifndef FOO_H`
+            // include-guard idiom wraps an entire header. Both arms of an
+            // `#if/#else` are extracted: deciding which one compiles needs a
+            // preprocessor, and dropping both is strictly worse.
+            "preproc_if" | "preproc_ifdef" | "preproc_else" | "preproc_elif"
+            | "preproc_elifdef" => Self::visit_children(state, node),
             "type_definition" => Self::visit_type_definition(state, node),
             "protocol_declaration" => Self::visit_protocol(state, node),
             "class_interface" => Self::visit_class_interface(state, node),

--- a/tests/c_extraction_test.rs
+++ b/tests/c_extraction_test.rs
@@ -555,3 +555,35 @@ fn test_c_language_name() {
     let extractor = CExtractor;
     assert_eq!(extractor.language_name(), "C");
 }
+
+#[test]
+fn test_c_symbols_inside_preproc_conditional() {
+    let source = r#"
+#ifdef FEATURE_X
+int feature_fn(int a) {
+    return a + 1;
+}
+#endif
+"#;
+    let extractor = CExtractor;
+    let result = extractor.extract("feature.c", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let names: Vec<_> = result.nodes.iter().map(|n| n.name.as_str()).collect();
+    assert!(names.contains(&"feature_fn"), "nodes: {:?}", names);
+}
+
+#[test]
+fn test_c_symbols_inside_include_guard() {
+    let source = r#"
+#ifndef LIST_H
+#define LIST_H
+struct List { int len; };
+int list_len(struct List* l);
+#endif
+"#;
+    let extractor = CExtractor;
+    let result = extractor.extract("list.h", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let names: Vec<_> = result.nodes.iter().map(|n| n.name.as_str()).collect();
+    assert!(names.contains(&"List"), "nodes: {:?}", names);
+}

--- a/tests/cpp_extraction_test.rs
+++ b/tests/cpp_extraction_test.rs
@@ -883,3 +883,56 @@ void normal_func(int x) {
     assert!(fns.contains(&"wrapped"), "functions: {fns:?}");
     assert!(fns.contains(&"normal_func"), "functions: {fns:?}");
 }
+
+#[test]
+fn test_cpp_symbols_inside_preproc_conditional() {
+    let source = r#"
+#if !NDEBUG
+int guarded_fn(int a) {
+    return a + 1;
+}
+struct GuardedStruct { int x; };
+#endif
+"#;
+    let extractor = CppExtractor;
+    let result = extractor.extract("guarded.cpp", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let names: Vec<_> = result.nodes.iter().map(|n| n.name.as_str()).collect();
+    assert!(names.contains(&"guarded_fn"), "nodes: {:?}", names);
+    assert!(names.contains(&"GuardedStruct"), "nodes: {:?}", names);
+}
+
+#[test]
+fn test_cpp_symbols_inside_include_guard() {
+    let source = r#"
+#ifndef WIDGET_H
+#define WIDGET_H
+class Widget {
+public:
+    void Draw();
+};
+#endif
+"#;
+    let extractor = CppExtractor;
+    let result = extractor.extract("widget.h", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let names: Vec<_> = result.nodes.iter().map(|n| n.name.as_str()).collect();
+    assert!(names.contains(&"Widget"), "nodes: {:?}", names);
+}
+
+#[test]
+fn test_cpp_extracts_both_preproc_branches() {
+    let source = r#"
+#if defined(PLATFORM_A)
+int platform_init(void) { return 1; }
+#else
+int platform_fallback(void) { return 2; }
+#endif
+"#;
+    let extractor = CppExtractor;
+    let result = extractor.extract("platform.cpp", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let names: Vec<_> = result.nodes.iter().map(|n| n.name.as_str()).collect();
+    assert!(names.contains(&"platform_init"), "nodes: {:?}", names);
+    assert!(names.contains(&"platform_fallback"), "nodes: {:?}", names);
+}

--- a/tests/objc_extraction_test.rs
+++ b/tests/objc_extraction_test.rs
@@ -587,3 +587,18 @@ fn test_objc_full_sample_file() {
         contains.len()
     );
 }
+
+#[test]
+fn test_objc_symbols_inside_preproc_conditional() {
+    let source = r#"
+#ifdef DEBUG
+void debug_log(const char* msg) {
+}
+#endif
+"#;
+    let extractor = ObjcExtractor;
+    let result = extractor.extract("logging.m", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let names: Vec<_> = result.nodes.iter().map(|n| n.name.as_str()).collect();
+    assert!(names.contains(&"debug_log"), "nodes: {:?}", names);
+}


### PR DESCRIPTION
## Problem

The C, C++, and Objective-C extractors dispatch `preproc_def` and `preproc_include`, but no conditional node kind. `preproc_if`, `preproc_ifdef`, `preproc_else`, `preproc_elif` and `preproc_elifdef` therefore fall through `visit_node`'s catch-all arm, and every symbol declared inside a conditional block is silently dropped.

The failure is quiet and reads as a valid answer: the affected file still indexes as a file node with zero symbols, so `search` returns `[]` rather than an error.

It costs whole files rather than isolated symbols, because two extremely common idioms wrap an entire file in a conditional:

- `#ifndef FOO_H / #define FOO_H ... #endif` include guards -- most C and C++ headers that do not use `#pragma once`
- build-config guards (`#if !NDEBUG`, `#if !SOME_SHIPPING_FLAG`, ...) wrapping a whole translation unit

Minimal repro:

```cpp
// extracts: OutsideGuard
int OutsideGuard(int a) { return a + 1; }
```

```cpp
// extracts nothing
#if !NDEBUG
int InsideGuard(int a) { return a + 1; }
struct InsideStruct { int x; };
#endif
```

```cpp
// extracts nothing -- the classic include guard
#ifndef WIDGET_H
#define WIDGET_H
class Widget { public: void Draw(); };
#endif
```

## Fix

Unwrap the conditional kinds into `visit_children`, alongside the existing `linkage_specification` / `declaration_list` arm. A conditional block carries no symbol itself; its body does.

Both arms of an `#if/#else` are extracted. Deciding which one compiles needs a real preprocessor with the project's define set, and reporting a symbol that some configuration excludes is strictly better than dropping both -- it matches how tag generators handle the same ambiguity.

## Impact

Measured on one ~200-file C++ tree that uses build-config guards heavily:

| | before | after |
|---|---|---|
| nodes | 3592 | 4179 |
| edges | 2438 | 6717 |

16 files went from zero symbols to fully indexed. The edge count nearly tripling is the notable part -- call edges into and out of guarded code were absent from the graph entirely.

## Tests

Six new tests across the three languages, covering the guarded-block, include-guard, and both-branches cases. Each fails on `main` and passes with the fix.

Full suite: `cargo test` passes. Two pre-existing failures in `global::gather_tests` (`empty_dir_yields_empty_result`, `finds_project_at_cwd`) reproduce identically on an unpatched checkout on this machine and are unrelated to extraction.
