### PR TITLE
fix(extraction): merge duplicated C++ visit_children match arms

### DIFF
--- a/src/extraction/cpp_extractor.rs
+++ b/src/extraction/cpp_extractor.rs
@@ -185,16 +185,22 @@ impl CppExtractor {
             // via `extern "C"`; namespaces already unwrap their own
             // `declaration_list` before dispatch, so this can't double-visit
             // them.
-            "linkage_specification" | "declaration_list" => Self::visit_children(state, node),
-            // A conditional block carries no symbol itself, but its body does.
-            // Without this every declaration inside an `#if` / `#ifdef` is
-            // invisible -- which silently drops whole files: the `#ifndef FOO_H`
-            // include-guard idiom wraps an entire header, and build-config
-            // guards (`#if !NDEBUG` and friends) wrap entire .cpp files.
-            // Both arms of an `#if/#else` are extracted: deciding which one
-            // compiles needs a preprocessor, and dropping both is strictly
-            // worse than reporting a symbol that some configuration excludes.
-            "preproc_if" | "preproc_ifdef" | "preproc_else" | "preproc_elif"
+            //
+            // A preprocessor conditional likewise carries no symbol itself
+            // while its body does. Without it every declaration inside an
+            // `#if` / `#ifdef` is invisible -- which silently drops whole
+            // files: the `#ifndef FOO_H` include-guard idiom wraps an entire
+            // header, and build-config guards (`#if !NDEBUG` and friends)
+            // wrap entire .cpp files. Both arms of an `#if/#else` are
+            // extracted: deciding which one compiles needs a preprocessor,
+            // and dropping both is strictly worse than reporting a symbol
+            // that some configuration excludes.
+            "linkage_specification"
+            | "declaration_list"
+            | "preproc_if"
+            | "preproc_ifdef"
+            | "preproc_else"
+            | "preproc_elif"
             | "preproc_elifdef" => Self::visit_children(state, node),
             _ => {
                 // For other node types, skip. Comments are picked up as docstrings.


### PR DESCRIPTION
Follow-up to #388, which landed with a `clippy::match_same_arms` violation.

The preprocessor-conditional arm added for C++ has the same body as the `linkage_specification`/`declaration_list` arm immediately above it. Merged the patterns into one arm; behaviour is identical and both rationales are preserved in the comment.

### Why #388's CI didn't catch it

The Clippy job in `.github/workflows/ci.yml` runs:

```yaml
  clippy:
    continue-on-error: true
    ...
      - run: cargo clippy --workspace --all-targets
```

No `-D warnings`, and `continue-on-error: true` on top. That job reports success unconditionally — a red Clippy check is not currently possible. The repo's own pre-commit hook *does* run `cargo clippy --workspace --all-targets -- -D warnings`, so the lint blocks contributors locally while CI stays green on the same code.

Worth deciding separately whether to drop `continue-on-error` and add `-D warnings` so the two agree; I've left the workflow alone here to keep this a single-purpose fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)