### PR TITLE
docs(readme): add the Lulu marketplace listing badge, unlinked

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@
   <img src="https://img.shields.io/badge/Linux-supported-blue.svg" alt="Linux">
   <img src="https://img.shields.io/badge/Windows-supported-blue.svg" alt="Windows">
   <a href="https://hypercommit.com/tokensave"><img src="https://img.shields.io/badge/Hypercommit-DB2475" alt="Hypercommit"></a>
+  <!-- Listing badge only. Deliberately not wrapped in a link: the badge's own
+       href points at a monetization page on the marketplace's side (#406). -->
+  <img src="https://getlulu.dev/api/mcps/badge/tokensave" alt="Listed in the Lulu MCP marketplace">
 </p>
 
 ---


### PR DESCRIPTION
Closes #406.

Adds the badge from #406 to the existing marketplace badge row, **without** wrapping it in a link.

The reporter disclosed that the badge as offered links to a monetization page on their side. The bare image conveys the listing just as well, without pointing readers from this README at a paywall, and without the README appearing to co-sign a `top-ranked dev-tools server` claim about the marketplace's own index that we have no way to verify. A comment above the badge records why the link is absent, so a future edit doesn't 'helpfully' add one back.

Verified the URL resolves: `HTTP 200`, `image/svg+xml`, 4193 bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)