### PR TITLE
feat(ruby): extract attr_reader/attr_writer/attr_accessor as method nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project uses [maintenance-based versioning](TOKENSAVE-VERSIONING.md), n
 ## [Unreleased]
 
 ### Added
+- **Ruby `attr_reader`/`attr_writer`/`attr_accessor` now emit method nodes.** A receiverless `attr_*` call in a class or module body is indexed the same way an equivalent `def` would be — same kind, visibility, parent, and `Contains` edge — including inside `class << self` and Concern `included`/`class_methods` blocks. Previously these accessors were invisible to search, callers, and dead-code analysis.
+
+### Added
 - **`tokensave_ambiguous_calls`: the candidates behind a call the resolver could not pin down (#412).** #378 stopped fabricating an edge when several targets tied, which was right — an edge asserts a specific target and "one of these" is not one — but it discarded what the resolver knew. The candidates are now recorded (schema v17, `ambiguous_calls`) and readable, so the ambiguity becomes data rather than silence. A model has the source in front of it and can usually tell which `dispose` was meant from the receiver's type, which a scoring heuristic cannot see; it can only do that if it is told there was a choice. Each call site is returned with its unresolved reference and every candidate's name, kind, file, line and qualified name, scoped by `path` and capped (default 25, max 200 — a hard cap, not a page, since a large codebase can hold thousands). **`dead_code` now excludes symbols named as an ambiguity candidate**: having refused the edge, reporting the target as uncalled would trade a fabricated edge for a fabricated finding, and a finding reads as more actionable than an edge — the same mistake #346 measured at a 97% false-positive rate, in the other direction. No edges are created, so the refusal's guarantee is intact. Ambiguity is computed only for references that already failed to resolve, so the cost falls on a minority of refs rather than threading state through the parallel resolution pass.
 
 ### Fixed

--- a/src/extraction/ruby_extractor.rs
+++ b/src/extraction/ruby_extractor.rs
@@ -196,11 +196,14 @@ impl RubyExtractor {
             }
             // Bare `private`/`protected`/`public` mode switches parse as a plain
             // identifier statement; defensively also handle a no-arg call.
-            // A receiverless include/prepend/extend is a mixin directive; the two
-            // handlers are gated on disjoint method names, so both run.
+            // A receiverless include/prepend/extend is a mixin directive, and a
+            // receiverless attr_reader/attr_writer/attr_accessor is an attribute
+            // directive; all three handlers are gated on disjoint method names,
+            // so all three run.
             "identifier" | "call" | "method_call" => {
                 Self::visit_visibility_directive(state, node);
                 Self::visit_mixin_directive(state, node);
+                Self::visit_attribute_directive(state, node);
                 Self::visit_expression_blocks(state, node);
             }
             // Statement containers: they wrap statements without opening a new
@@ -966,9 +969,21 @@ impl RubyExtractor {
                                     }
                                 }
                             }
+                            "call" | "method_call" => {
+                                // `private attr_reader :foo`: the arg is a nested
+                                // attribute-directive call. Ruby applies the directive to
+                                // it and returns without switching the default visibility
+                                // mode, so re-dispatch it here with `visibility_mode`
+                                // temporarily set, the same way the `"method"` arm above
+                                // does for `private def foo; end`.
+                                saw_arg = true;
+                                let saved_visibility_mode = state.visibility_mode.clone();
+                                state.visibility_mode = visibility.clone();
+                                Self::visit_attribute_directive(state, arg);
+                                state.visibility_mode = saved_visibility_mode;
+                            }
                             _ => {
-                                // Any other named argument (e.g. `private attr_reader :foo`,
-                                // whose arg is a nested `call`) is still an argument: Ruby
+                                // Any other named argument is still an argument: Ruby
                                 // applies the directive to it and returns without switching
                                 // the default visibility. Unnamed nodes (punctuation like
                                 // `(`, `)`, `,`) don't count, so `private()` still switches
@@ -1092,6 +1107,190 @@ impl RubyExtractor {
                 });
             }
         }
+    }
+
+    /// Extract `attr_reader`/`attr_writer`/`attr_accessor` declarations as
+    /// method nodes, the same shape `visit_method` would produce for the
+    /// equivalent `def` — `attr_reader :x` yields `x`, `attr_writer :x`
+    /// yields `x=`, `attr_accessor :x` yields both (confirmed against Ruby
+    /// 3.4.7's `Module#attr_*` return value and `instance_methods`).
+    ///
+    /// Guard sequence mirrors `visit_mixin_directive`: a call with an
+    /// explicit receiver is an ordinary method call that merely shares the
+    /// name, not the DSL (`obj.attr_accessor :x` raises `NoMethodError` on
+    /// any receiver but a `Module`, confirmed against Ruby 3.4.7); a
+    /// top-level directive (`class_depth == 0`) attaches to `Object`, which
+    /// has no node to hang it on, same reasoning as a top-level `include`.
+    /// `class_depth > 0` also covers `class << self`/`class << other` bodies
+    /// (they don't touch `class_depth`, but can't be reached with it at 0
+    /// either — same as `visit_method`'s `in_class` check), so the
+    /// `Function`-kind case `visit_method` has to handle never arises here.
+    ///
+    /// Only `simple_symbol` and `delimited_symbol` (static form) arguments
+    /// are resolvable at extraction time, reusing
+    /// `visit_visibility_directive`'s symbol handling; a string literal (also
+    /// valid Ruby here, but out of this PR's scope), a splat, or a plain
+    /// identifier (dynamic) argument emits nothing rather than fabricating a
+    /// node.
+    ///
+    /// Not guarded against firing from inside a `def` body (`def install;
+    /// attr_accessor :x; end`, which only actually defines `x`/`x=` if
+    /// `install` runs, and only on `A.new.install` — `x` is fabricated
+    /// unconditionally here regardless). This mirrors an identical
+    /// pre-existing gap in `visit_mixin_directive` (confirmed:
+    /// `include`/`attr_accessor` alike raise `NoMethodError` when the
+    /// ambient `self` inside the body is an instance rather than a module,
+    /// but neither handler checks `self_is_instance`); closing it for every
+    /// DSL directive handler at once is a separate improvement, not specific
+    /// to `attr_*`.
+    fn visit_attribute_directive(state: &mut ExtractionState, node: TsNode<'_>) {
+        if node.child_by_field_name("receiver").is_some() {
+            return;
+        }
+        let Some(method_node) = node.child_by_field_name("method") else {
+            return;
+        };
+        let method_name = state.node_text(method_node);
+        let (readable, writable) = match method_name.as_str() {
+            "attr_reader" => (true, false),
+            "attr_writer" => (false, true),
+            "attr_accessor" => (true, true),
+            _ => return,
+        };
+        if state.class_depth == 0 {
+            return;
+        }
+        let Some(parent_id) = state.parent_node_id().map(str::to_string) else {
+            return;
+        };
+        let Some(arguments) = node.child_by_field_name("arguments") else {
+            return;
+        };
+
+        let docstring = Self::extract_docstring(state, node);
+        let start_line = node.start_position().row as u32;
+        let end_line = node.end_position().row as u32;
+        let start_column = node.start_position().column as u32;
+        let end_column = node.end_position().column as u32;
+        let kind = if state.singleton_scope == SingletonScope::Enclosing {
+            NodeKind::SingletonMethod
+        } else {
+            NodeKind::Method
+        };
+        let visibility = state.visibility_mode.clone();
+
+        let mut cursor = arguments.walk();
+        for arg in arguments.named_children(&mut cursor) {
+            let attr_name = match arg.kind() {
+                "simple_symbol" => Some(state.node_text(arg).trim_start_matches(':').to_string()),
+                "delimited_symbol" => Self::static_delimited_symbol_name(state, arg),
+                _ => None,
+            };
+            let Some(attr_name) = attr_name else {
+                continue;
+            };
+            if readable {
+                Self::emit_attribute_method(
+                    state,
+                    &attr_name,
+                    false,
+                    kind.clone(),
+                    visibility.clone(),
+                    &parent_id,
+                    docstring.clone(),
+                    (start_line, end_line, start_column, end_column),
+                );
+            }
+            if writable {
+                Self::emit_attribute_method(
+                    state,
+                    &attr_name,
+                    true,
+                    kind.clone(),
+                    visibility.clone(),
+                    &parent_id,
+                    docstring.clone(),
+                    (start_line, end_line, start_column, end_column),
+                );
+            }
+        }
+    }
+
+    /// Build and register one method node for one generated accessor
+    /// (`attr_name` for a reader, `attr_name=` for a writer), attached to
+    /// `parent_id`. Shares `visit_method`'s node shape (zeroed complexity
+    /// metrics — there's no body to measure), `Contains` edge, and
+    /// singleton-method-id bookkeeping so a later `private_class_method` can
+    /// retroactively find it.
+    #[allow(clippy::too_many_arguments)]
+    fn emit_attribute_method(
+        state: &mut ExtractionState,
+        attr_name: &str,
+        is_writer: bool,
+        kind: NodeKind,
+        visibility: Visibility,
+        parent_id: &str,
+        docstring: Option<String>,
+        (start_line, end_line, start_column, end_column): (u32, u32, u32, u32),
+    ) {
+        let name = if is_writer {
+            format!("{attr_name}=")
+        } else {
+            attr_name.to_string()
+        };
+        // Synthetic signature matching what extract_method_signature would
+        // produce for the equivalent `def name` / `def name=(value)`.
+        let signature = Some(if is_writer {
+            format!("def {name}(value)")
+        } else {
+            format!("def {name}")
+        });
+        let qualified_name = format!("{}::{}", state.qualified_prefix(), name);
+        let id = generate_node_id(&state.file_path, &kind, &name, start_line);
+
+        let graph_node = Node {
+            id: id.clone(),
+            kind,
+            name,
+            qualified_name,
+            file_path: state.file_path.clone(),
+            start_line,
+            attrs_start_line: start_line,
+            end_line,
+            start_column,
+            end_column,
+            signature,
+            docstring,
+            visibility,
+            is_async: false,
+            branches: 0,
+            loops: 0,
+            returns: 0,
+            max_nesting: 0,
+            unsafe_blocks: 0,
+            unchecked_calls: 0,
+            assertions: 0,
+            cognitive_complexity: 0,
+            distinct_operators: 0,
+            distinct_operands: 0,
+            total_operators: 0,
+            total_operands: 0,
+            updated_at: state.timestamp,
+            parent_id: None,
+        };
+        state.nodes.push(graph_node);
+        match state.singleton_scope {
+            SingletonScope::Enclosing => state.singleton_method_ids.push(id.clone()),
+            SingletonScope::Foreign => state.foreign_singleton_method_ids.push(id.clone()),
+            SingletonScope::Outside => {}
+        }
+
+        state.edges.push(Edge {
+            source: parent_id.to_string(),
+            target: id,
+            kind: EdgeKind::Contains,
+            line: Some(start_line),
+        });
     }
 
     /// Classify a call's block by the default-definee rule documented on

--- a/tests/ruby_extraction_test.rs
+++ b/tests/ruby_extraction_test.rs
@@ -371,6 +371,15 @@ end
             .find(|n| n.name == "visible")
             .expect("expected visible method");
         assert_eq!(visible.visibility, Visibility::Pub);
+        // `private attr_reader :foo` applies the directive to its argument
+        // (recursing into visit_attribute_directive), so foo itself is
+        // Private even though the default mode doesn't switch.
+        let foo = result
+            .nodes
+            .iter()
+            .find(|n| n.name == "foo")
+            .expect("expected foo reader method from private attr_reader :foo");
+        assert_eq!(foo.visibility, Visibility::Private);
     }
 
     #[test]
@@ -3869,5 +3878,426 @@ end
             .expect("expected m method defined inside install's each block");
         assert_eq!(m.kind, NodeKind::Method);
         assert!(m.qualified_name.ends_with("C::m"));
+    }
+
+    // --- attr_reader / attr_writer / attr_accessor -------------------------
+
+    #[test]
+    fn test_ruby_attr_reader_defines_reader_only() {
+        let source = r#"
+class Widget
+  attr_reader :x
+end
+"#;
+        let extractor = RubyExtractor;
+        let result = extractor.extract("widget.rb", source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        let x = result
+            .nodes
+            .iter()
+            .find(|n| n.name == "x")
+            .expect("expected x reader method");
+        assert_eq!(x.kind, NodeKind::Method);
+        assert!(x.qualified_name.ends_with("Widget::x"));
+        assert!(
+            !result.nodes.iter().any(|n| n.name == "x="),
+            "attr_reader must not define a writer"
+        );
+    }
+
+    #[test]
+    fn test_ruby_attr_writer_defines_writer_only() {
+        let source = r#"
+class Widget
+  attr_writer :y
+end
+"#;
+        let extractor = RubyExtractor;
+        let result = extractor.extract("widget.rb", source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        let y = result
+            .nodes
+            .iter()
+            .find(|n| n.name == "y=")
+            .expect("expected y= writer method");
+        assert_eq!(y.kind, NodeKind::Method);
+        assert!(y.qualified_name.ends_with("Widget::y="));
+        assert!(
+            !result.nodes.iter().any(|n| n.name == "y"),
+            "attr_writer must not define a reader"
+        );
+    }
+
+    #[test]
+    fn test_ruby_attr_accessor_defines_reader_and_writer() {
+        let source = r#"
+class Widget
+  attr_accessor :z
+end
+"#;
+        let extractor = RubyExtractor;
+        let result = extractor.extract("widget.rb", source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        assert!(result.nodes.iter().any(|n| n.name == "z"));
+        assert!(result.nodes.iter().any(|n| n.name == "z="));
+    }
+
+    #[test]
+    fn test_ruby_attr_accessor_multiple_symbols() {
+        let source = r#"
+class Widget
+  attr_accessor :a, :b
+end
+"#;
+        let extractor = RubyExtractor;
+        let result = extractor.extract("widget.rb", source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        for name in ["a", "a=", "b", "b="] {
+            assert!(
+                result.nodes.iter().any(|n| n.name == name),
+                "expected {name} from attr_accessor :a, :b"
+            );
+        }
+    }
+
+    #[test]
+    fn test_ruby_attr_reader_delimited_symbol_extracted() {
+        let source = r#"
+class Widget
+  attr_reader :"total"
+end
+"#;
+        let extractor = RubyExtractor;
+        let result = extractor.extract("widget.rb", source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        assert!(result.nodes.iter().any(|n| n.name == "total"));
+    }
+
+    #[test]
+    fn test_ruby_attr_reader_interpolated_symbol_not_extracted() {
+        let source = r##"
+class Widget
+  attr_reader :"#{name}"
+end
+"##;
+        let extractor = RubyExtractor;
+        let result = extractor.extract("widget.rb", source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        assert_eq!(
+            result
+                .nodes
+                .iter()
+                .filter(|n| n.kind == NodeKind::Method)
+                .count(),
+            0,
+            "an interpolated symbol name can't be resolved statically"
+        );
+    }
+
+    #[test]
+    fn test_ruby_attr_accessor_splat_not_extracted() {
+        let source = r#"
+class Widget
+  syms = [:a, :b]
+  attr_accessor(*syms)
+end
+"#;
+        let extractor = RubyExtractor;
+        let result = extractor.extract("widget.rb", source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        assert!(
+            !result.nodes.iter().any(|n| n.kind == NodeKind::Method),
+            "a splat argument's names aren't known at extraction time: {:?}",
+            result.nodes.iter().map(|n| &n.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_ruby_attr_accessor_dynamic_identifier_not_extracted() {
+        let source = r#"
+class Widget
+  h = :h
+  attr_accessor h
+end
+"#;
+        let extractor = RubyExtractor;
+        let result = extractor.extract("widget.rb", source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        assert!(
+            !result.nodes.iter().any(|n| n.kind == NodeKind::Method),
+            "a variable argument's value isn't known at extraction time: {:?}",
+            result.nodes.iter().map(|n| &n.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_ruby_attr_accessor_string_argument_not_extracted() {
+        // `attr_accessor "c"` is valid Ruby, but string-literal arguments are
+        // deliberately out of this PR's scope (see visit_attribute_directive).
+        let source = r#"
+class Widget
+  attr_accessor "c"
+end
+"#;
+        let extractor = RubyExtractor;
+        let result = extractor.extract("widget.rb", source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        assert!(
+            !result.nodes.iter().any(|n| n.kind == NodeKind::Method),
+            "string-literal arguments are out of scope: {:?}",
+            result.nodes.iter().map(|n| &n.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_ruby_attr_accessor_explicit_receiver_not_extracted() {
+        let source = r#"
+class Widget
+  def install(obj)
+    obj.attr_accessor :x
+  end
+end
+"#;
+        let extractor = RubyExtractor;
+        let result = extractor.extract("widget.rb", source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        assert!(
+            !result.nodes.iter().any(|n| n.name == "x"),
+            "obj.attr_accessor is an ordinary call on obj, not the DSL"
+        );
+    }
+
+    #[test]
+    fn test_ruby_top_level_attr_accessor_not_extracted() {
+        let source = r#"
+attr_accessor :x
+"#;
+        let extractor = RubyExtractor;
+        let result = extractor.extract("top.rb", source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        assert!(
+            !result.nodes.iter().any(|n| n.name == "x"),
+            "a top-level attr_accessor defines on Object, which has no node"
+        );
+    }
+
+    #[test]
+    fn test_ruby_module_attr_accessor_defines_method() {
+        let source = r#"
+module Trackable
+  attr_accessor :x
+end
+"#;
+        let extractor = RubyExtractor;
+        let result = extractor.extract("trackable.rb", source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        let x = result
+            .nodes
+            .iter()
+            .find(|n| n.name == "x")
+            .expect("expected x method inside module body");
+        assert!(x.qualified_name.ends_with("Trackable::x"));
+    }
+
+    #[test]
+    fn test_ruby_bare_private_then_attr_reader_is_private() {
+        let source = r#"
+class Widget
+  private
+
+  attr_reader :x
+end
+"#;
+        let extractor = RubyExtractor;
+        let result = extractor.extract("widget.rb", source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        let x = result
+            .nodes
+            .iter()
+            .find(|n| n.name == "x")
+            .expect("expected x reader method");
+        assert_eq!(x.visibility, Visibility::Private);
+    }
+
+    #[test]
+    fn test_ruby_singleton_class_attr_accessor_is_singleton_method() {
+        let source = r#"
+class Report
+  class << self
+    attr_accessor :x
+  end
+end
+"#;
+        let extractor = RubyExtractor;
+        let result = extractor.extract("report.rb", source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        let x = result
+            .nodes
+            .iter()
+            .find(|n| n.name == "x")
+            .expect("expected x method inside class << self");
+        assert_eq!(x.kind, NodeKind::SingletonMethod);
+    }
+
+    #[test]
+    fn test_ruby_singleton_class_attr_accessor_privatized_by_private_class_method() {
+        let source = r#"
+class Report
+  class << self
+    attr_accessor :x
+  end
+
+  private_class_method :x
+end
+"#;
+        let extractor = RubyExtractor;
+        let result = extractor.extract("report.rb", source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        let x = result
+            .nodes
+            .iter()
+            .find(|n| n.name == "x")
+            .expect("expected x singleton method");
+        assert_eq!(x.visibility, Visibility::Private);
+    }
+
+    #[test]
+    fn test_ruby_attr_accessor_contains_edge_from_enclosing_class() {
+        let source = r#"
+class Widget
+  attr_accessor :x
+end
+"#;
+        let extractor = RubyExtractor;
+        let result = extractor.extract("widget.rb", source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        let class_node = result
+            .nodes
+            .iter()
+            .find(|n| n.kind == NodeKind::Class && n.name == "Widget")
+            .expect("expected Widget class");
+        let x = result
+            .nodes
+            .iter()
+            .find(|n| n.name == "x")
+            .expect("expected x method");
+        assert!(
+            result.edges.iter().any(|e| e.kind == EdgeKind::Contains
+                && e.source == class_node.id
+                && e.target == x.id),
+            "expected Contains edge from Widget directly to x"
+        );
+    }
+
+    #[test]
+    fn test_ruby_attr_reader_docstring_attaches() {
+        // attr_reader :other comes first so the comment is a body_statement
+        // sibling of the call it documents, not (per a tree-sitter-ruby
+        // quirk affecting the first statement of any kind) a sibling of the
+        // class's body field instead.
+        let source = r#"
+class Widget
+  attr_reader :other
+
+  # The running total.
+  attr_reader :total
+end
+"#;
+        let extractor = RubyExtractor;
+        let result = extractor.extract("widget.rb", source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        let total = result
+            .nodes
+            .iter()
+            .find(|n| n.name == "total")
+            .expect("expected total reader method");
+        assert_eq!(total.docstring.as_deref(), Some("The running total."));
+    }
+
+    #[test]
+    fn test_ruby_included_do_block_attr_accessor_defines_instance_method() {
+        let source = r#"
+module Trackable
+  extend ActiveSupport::Concern
+
+  included do
+    attr_accessor :x
+  end
+end
+"#;
+        let extractor = RubyExtractor;
+        let result = extractor.extract("trackable.rb", source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        let x = result
+            .nodes
+            .iter()
+            .find(|n| n.name == "x")
+            .expect("expected x method inside included do block");
+        assert_eq!(x.kind, NodeKind::Method);
+        assert!(x.qualified_name.ends_with("Trackable::x"));
+    }
+
+    #[test]
+    fn test_ruby_class_methods_do_block_attr_accessor_is_singleton_method() {
+        let source = r#"
+module Trackable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    attr_accessor :x
+  end
+end
+"#;
+        let extractor = RubyExtractor;
+        let result = extractor.extract("trackable.rb", source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        let x = result
+            .nodes
+            .iter()
+            .find(|n| n.name == "x")
+            .expect("expected x method inside class_methods do block");
+        assert_eq!(x.kind, NodeKind::SingletonMethod);
+    }
+
+    #[test]
+    fn test_ruby_class_new_do_block_attr_accessor_not_extracted() {
+        let source = r#"
+class C
+  K = Class.new do
+    attr_accessor :x
+  end
+end
+"#;
+        let extractor = RubyExtractor;
+        let result = extractor.extract("c.rb", source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        assert!(
+            !result.nodes.iter().any(|n| n.name == "x"),
+            "Class.new's block must not leak x to the enclosing class C either"
+        );
+    }
+
+    // Known, accepted limitation (mirrors visit_mixin_directive's identical
+    // gap for include/extend/prepend): an attr_* call written directly inside
+    // a `def` body is unconditionally extracted here, even though in Ruby it
+    // only actually defines the accessor if that method runs, and only then
+    // because `self` inside it happens to be a module (a plain instance
+    // method's `self` is an instance and raises `NoMethodError` on
+    // `attr_accessor`, confirmed against Ruby 3.4.7). Fixing this needs a
+    // shared self_is_instance gate across every DSL directive handler, out
+    // of scope for this PR.
+    #[test]
+    fn test_ruby_attr_accessor_in_method_body_is_extracted_unconditionally() {
+        let source = r#"
+class Widget
+  def install
+    attr_accessor :x
+  end
+end
+"#;
+        let extractor = RubyExtractor;
+        let result = extractor.extract("widget.rb", source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        assert!(result.nodes.iter().any(|n| n.name == "x"));
     }
 } // mod ruby_tests


### PR DESCRIPTION
## Summary

- Ruby `attr_reader`/`attr_writer`/`attr_accessor` declarations now emit method nodes, matching the kind, visibility, parent, and `Contains` edge an equivalent `def` would produce.
- Fixes `private attr_reader :foo` landing public (visibility directive now recurses into the nested attribute-directive call, same as it already does for `private def foo; end`).

## Motivation

`attr_*` produced no node at all, which is worse than a missing edge: the method is invisible to search, `module_api`, `callers`, `rename_preview`, and `doc_coverage`, and any call to it is permanently unresolvable. Measured against a local Rails checkout, `attr_*` declarations (1,540) outnumber `define_method`/`alias_method`/`module_function` combined 5x, making it the dominant source of missing method nodes in application code.

## Changes

- `src/extraction/ruby_extractor.rs`:
  - New `visit_attribute_directive` handler, registered in the dispatch arm alongside `visit_visibility_directive`/`visit_mixin_directive`, modeled on `visit_mixin_directive`'s guard sequence (explicit receiver -> skip, `class_depth == 0` -> skip, arguments required). Only `simple_symbol` and static `delimited_symbol` arguments resolve to a name; string/splat/dynamic-identifier arguments emit nothing rather than fabricate a node.
  - Node construction mirrors `visit_method`: `SingletonMethod` inside `class << self`, visibility from `visibility_mode`, position from the `attr_*` call node, a synthesized signature (`def x` / `def x=(value)`), and `singleton_method_ids`/`foreign_singleton_method_ids` registration so a later `private_class_method` can find it.
  - `visit_visibility_directive`'s catch-all argument arm now recurses into a nested `attr_*` call with `visibility_mode` temporarily set, fixing `private attr_reader :foo`.
  - Because `attr_*` reuses `visit_method`'s existing `class_depth`/`singleton_scope` state machine, it gets correct behavior for free at `class << self`, Concern `included do`/`class_methods do`, and `Class.new do` — no new state needed there.
  - One gap deliberately left open (documented inline): an `attr_*` call written directly inside a `def` body is extracted unconditionally, mirroring an identical pre-existing gap in `visit_mixin_directive` for `include`/`extend`/`prepend`. Fixing it needs a shared `self_is_instance` gate across every DSL directive handler, not a special case for `attr_*` — tracked as follow-up.
- `tests/ruby_extraction_test.rs`: one test per truth-table row (reader/writer/accessor, multiple symbols, delimited vs. interpolated symbols, splat/dynamic/string arguments as negatives, explicit receiver, top-level, module body, `class << self` + `private_class_method`, `Contains` edge, docstring, `included do`/`class_methods do`, `Class.new do`, and the method-body gap case).
- `CHANGELOG.md`: entry under `[Unreleased]`.

Full probe notes (Ruby 3.4.7 semantics, tree-sitter-ruby grammar shapes, the site x behavior table, and the mutation-check results) are in the commit body.

## Test plan

- [x] `cargo test` passes (774 lib tests, 165 Ruby integration tests)
- [x] `cargo clippy --workspace --all-targets` has no new warnings
- [x] `cargo fmt --all -- --check` clean
- [x] Mutation-checked every new predicate (reverted one at a time, confirmed exactly its own test failed)
- [x] Tested manually: built the binary, ran `tokensave init` on a scratch fixture covering every truth-table row, queried `.tokensave/tokensave.db` directly to confirm expected nodes present/absent
- [x] Tested against a local Rails checkout (read-only corpus, synced into a throwaway copy): +2,403 method-kind nodes against 1,540 `attr_*` declarations, and spot-checked `ActiveSupport::TimeZone#name` resolves with the correct qualified name, kind, and visibility

## Checklist

- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [x] No secrets, credentials, or `.env` files included
- [x] No breaking changes
