### PR TITLE
fix(githooks): exit non-zero when a hook could not be installed (#488)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project uses [maintenance-based versioning](TOKENSAVE-VERSIONING.md), n
 
 
 
+### Fixed
+
+- **`githooks on` no longer exits 0 after failing to install a hook (#488).** Both paths printed a red `✘ Failed to open … for writing` and then returned success, so a setup script gating on the exit code carried on with no hooks installed and no way to tell. The global path called `write_global_hook`, which returns a `bool`, in an `if` whose `else` did not exist; the local path collected `installed` and `already_present` but had nowhere to put a hook that failed. `offer_git_post_commit_hook` now returns `Result<(), String>` and `LocalHookInstall` carries a `failed` list, which `githooks on` turns into a non-zero exit naming the hooks. Failures are collected rather than raised at the first one: the command installs three hooks, and bailing early would skip the two the user also asked for. Declining the prompt, an already-present hook, and the best-effort call inside `install` all stay success — only an explicit `githooks on` that could not do what it was asked now fails.
+
 ## [7.11.0] - 2026-08-30
 
 ### Added

--- a/src/agents/hooks.rs
+++ b/src/agents/hooks.rs
@@ -118,17 +118,21 @@ fn install_repo_hook_forwarders(
     hooks_dir: &Path,
     claiming_hookspath: bool,
     hooks_dir_is_default: bool,
-) {
+) -> Vec<&'static str> {
+    let mut failed = Vec::new();
     if !(claiming_hookspath || hooks_dir_is_default) {
-        return;
+        return failed;
     }
     for name in FORWARDED_REPO_HOOKS {
         let path = hooks_dir.join(name);
         if path.exists() {
             continue;
         }
-        write_global_hook(&path, &chain_repo_hook_snippet(name));
+        if !write_global_hook(&path, &chain_repo_hook_snippet(name)) {
+            failed.push(*name);
+        }
     }
+    failed
 }
 
 /// Whether the chaining preamble should be added to a global hook file.
@@ -479,7 +483,11 @@ pub fn offer_git_post_commit_hook(tokensave_bin: &str, mode: GitHookMode) -> Res
     // hook type in each repo's .git/hooks/, not just the three tokensave owns.
     // Drop pure forwarders for the remaining client-side hooks so a repo's own
     // pre-commit / pre-push / commit-msg / … keep running.
-    install_repo_hook_forwarders(&hooks_dir, need_set_hookspath, hooks_dir_is_default);
+    failed.extend(install_repo_hook_forwarders(
+        &hooks_dir,
+        need_set_hookspath,
+        hooks_dir_is_default,
+    ));
 
     if failed.is_empty() {
         Ok(())

--- a/src/agents/hooks.rs
+++ b/src/agents/hooks.rs
@@ -290,8 +290,16 @@ pub(crate) fn decide_hook_action(mode: GitHookMode, hook_contents: Option<&str>)
 /// the hook is already present, if stdin is not a terminal, or if the user
 /// declines. The `mode` argument lets the caller pre-decide the answer so
 /// scripted installs do not have to drive an interactive prompt.
-pub fn offer_git_post_commit_hook(tokensave_bin: &str, mode: GitHookMode) {
-    let Some(home) = home_dir() else { return };
+///
+/// Returns `Err` only when the user asked for hooks and they could not be
+/// written. Declining, or a hook that is already present, is `Ok` — those are
+/// not failures. The specific reason is printed at the point of failure; the
+/// returned message exists so an explicit `githooks on` can exit non-zero
+/// instead of reporting a failed install as a success.
+pub fn offer_git_post_commit_hook(tokensave_bin: &str, mode: GitHookMode) -> Result<(), String> {
+    let Some(home) = home_dir() else {
+        return Ok(());
+    };
 
     // Determine the global hooks directory by reading core.hooksPath from
     // the global gitconfig file(s). Falls back to ~/.config/git/hooks/.
@@ -346,7 +354,7 @@ pub fn offer_git_post_commit_hook(tokensave_bin: &str, mode: GitHookMode) {
         HookAction::Skip => {
             // Mode `No` (or default-mode non-TTY). Stay quiet — script
             // callers asked for no output here.
-            return;
+            return Ok(());
         }
         HookAction::Prompt => {
             // TTY + default mode: ask, and bail entirely if the user declines.
@@ -356,11 +364,11 @@ pub fn offer_git_post_commit_hook(tokensave_bin: &str, mode: GitHookMode) {
             );
             let mut answer = String::new();
             if std::io::stdin().read_line(&mut answer).is_err() {
-                return;
+                return Ok(());
             }
             if !matches!(answer.trim(), "y" | "Y" | "yes" | "Yes") {
                 eprintln!("  Skipped git hooks");
-                return;
+                return Ok(());
             }
             true
         }
@@ -373,7 +381,7 @@ pub fn offer_git_post_commit_hook(tokensave_bin: &str, mode: GitHookMode) {
             "  \x1b[31m✘\x1b[0m Failed to create {}: {e}",
             hooks_dir.display()
         );
-        return;
+        return Err(format!("failed to create {}: {e}", hooks_dir.display()));
     }
 
     // If no global hooksPath was configured, set it in ~/.gitconfig.
@@ -381,7 +389,7 @@ pub fn offer_git_post_commit_hook(tokensave_bin: &str, mode: GitHookMode) {
         let gitconfig_path = home.join(".gitconfig");
         if let Err(msg) = set_global_hooks_path(&gitconfig_path, &hooks_dir) {
             eprintln!("  \x1b[31m✘\x1b[0m {msg} — hook not installed");
-            return;
+            return Err(format!("{msg} — hook not installed"));
         }
         eprintln!(
             "\x1b[32m✔\x1b[0m Set git core.hooksPath to {}",
@@ -400,11 +408,20 @@ pub fn offer_git_post_commit_hook(tokensave_bin: &str, mode: GitHookMode) {
         write_global_hook(&hook_path, &chain_repo_hook_snippet("post-commit"));
     }
 
-    if install_post_commit && write_global_hook(&hook_path, &post_commit_snippet(tokensave_bin)) {
-        eprintln!(
-            "\x1b[32m✔\x1b[0m Installed global git post-commit hook at {}",
-            hook_path.display()
-        );
+    // Hooks the user asked for whose write failed. Collected rather than
+    // returned early: this installs three hooks, and bailing on the first
+    // would skip the other two the user also asked for.
+    let mut failed: Vec<&str> = Vec::new();
+
+    if install_post_commit {
+        if write_global_hook(&hook_path, &post_commit_snippet(tokensave_bin)) {
+            eprintln!(
+                "\x1b[32m✔\x1b[0m Installed global git post-commit hook at {}",
+                hook_path.display()
+            );
+        } else {
+            failed.push("post-commit");
+        }
     }
 
     // Install the post-checkout hook so a fresh clone or worktree
@@ -422,12 +439,15 @@ pub fn offer_git_post_commit_hook(tokensave_bin: &str, mode: GitHookMode) {
         write_global_hook(&checkout_path, &chain_repo_hook_snippet("post-checkout"));
     }
     let checkout_present = checkout_contents.is_some_and(|c| c.contains(HOOK_MARKER_CHECKOUT));
-    if !checkout_present && write_global_hook(&checkout_path, &post_checkout_snippet(tokensave_bin))
-    {
-        eprintln!(
-            "\x1b[32m✔\x1b[0m Installed global git post-checkout hook at {}",
-            checkout_path.display()
-        );
+    if !checkout_present {
+        if write_global_hook(&checkout_path, &post_checkout_snippet(tokensave_bin)) {
+            eprintln!(
+                "\x1b[32m✔\x1b[0m Installed global git post-checkout hook at {}",
+                checkout_path.display()
+            );
+        } else {
+            failed.push("post-checkout");
+        }
     }
 
     // Install the post-merge hook so `git pull` (fast-forward or a real
@@ -444,11 +464,15 @@ pub fn offer_git_post_commit_hook(tokensave_bin: &str, mode: GitHookMode) {
         write_global_hook(&merge_path, &chain_repo_hook_snippet("post-merge"));
     }
     let merge_present = merge_contents.is_some_and(|c| c.contains(HOOK_MARKER_MERGE));
-    if !merge_present && write_global_hook(&merge_path, &post_merge_snippet(tokensave_bin)) {
-        eprintln!(
-            "\x1b[32m✔\x1b[0m Installed global git post-merge hook at {}",
-            merge_path.display()
-        );
+    if !merge_present {
+        if write_global_hook(&merge_path, &post_merge_snippet(tokensave_bin)) {
+            eprintln!(
+                "\x1b[32m✔\x1b[0m Installed global git post-merge hook at {}",
+                merge_path.display()
+            );
+        } else {
+            failed.push("post-merge");
+        }
     }
 
     // Issue #164 follow-up: claiming a global core.hooksPath disables *every*
@@ -456,6 +480,15 @@ pub fn offer_git_post_commit_hook(tokensave_bin: &str, mode: GitHookMode) {
     // Drop pure forwarders for the remaining client-side hooks so a repo's own
     // pre-commit / pre-push / commit-msg / … keep running.
     install_repo_hook_forwarders(&hooks_dir, need_set_hookspath, hooks_dir_is_default);
+
+    if failed.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "could not install git hooks: {}",
+            failed.join(", ")
+        ))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -471,6 +504,10 @@ pub struct LocalHookInstall {
     pub installed: Vec<String>,
     /// Hooks that already carried tokensave's section.
     pub already_present: Vec<String>,
+    /// Hooks whose write was attempted and failed. The reason was printed at
+    /// the point of failure; this records it so the caller can exit non-zero
+    /// rather than reporting a partial install as a success.
+    pub failed: Vec<String>,
     /// Set when a `core.hooksPath` is in effect for this repository, which
     /// makes git resolve every hook from *that* directory and ignore the one
     /// written here.
@@ -610,6 +647,8 @@ pub fn install_local_git_hooks(
         }
         if write_global_hook(&path, &snippet) {
             result.installed.push(name.to_string());
+        } else {
+            result.failed.push(name.to_string());
         }
     }
     Ok(result)

--- a/src/main.rs
+++ b/src/main.rs
@@ -825,7 +825,9 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
                 }
             }
 
-            tokensave::agents::offer_git_post_commit_hook(&tokensave_bin, git_hook);
+            // Best-effort during `install`: a hook that could not be written
+            // must not fail the whole install. The reason was already printed.
+            let _ = tokensave::agents::offer_git_post_commit_hook(&tokensave_bin, git_hook);
         }
         Commands::Reinstall {
             wildcard_permissions,
@@ -1201,17 +1203,35 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
                 (Some("on"), true) => {
                     let bin = current_bin_path();
                     match tokensave::agents::install_local_git_hooks(&repo, &bin) {
-                        Ok(outcome) => report_local_hook_install(&outcome),
+                        Ok(outcome) => {
+                            report_local_hook_install(&outcome);
+                            // The specific reason was already printed by
+                            // write_global_hook; this only stops an explicit
+                            // `githooks on --local` from reporting a partial
+                            // install as success.
+                            if !outcome.failed.is_empty() {
+                                return Err(tokensave::errors::TokenSaveError::Config {
+                                    message: format!(
+                                        "could not install git hooks: {}",
+                                        outcome.failed.join(", ")
+                                    ),
+                                });
+                            }
+                        }
                         Err(message) => {
                             return Err(tokensave::errors::TokenSaveError::Config { message })
                         }
                     }
                 }
                 (Some("on"), false) => {
-                    tokensave::agents::offer_git_post_commit_hook(
+                    // The specific reason was already printed; this only stops
+                    // `githooks on` from reporting a failed install as success.
+                    if let Err(message) = tokensave::agents::offer_git_post_commit_hook(
                         &current_bin_path(),
                         tokensave::agents::GitHookMode::Yes,
-                    );
+                    ) {
+                        return Err(tokensave::errors::TokenSaveError::Config { message });
+                    }
                 }
                 (Some(other), _) => {
                     return Err(tokensave::errors::TokenSaveError::Config {

--- a/tests/githooks_exit_code_test.rs
+++ b/tests/githooks_exit_code_test.rs
@@ -1,0 +1,72 @@
+//! `githooks on` must exit non-zero when it could not write the hooks.
+//!
+//! The library-level tests pin the failure *reporting*; these run the binary,
+//! because the bug in #488 was the wiring: the reason was printed in red and
+//! the command still exited 0, so any script gating on it saw a success.
+
+#![cfg(not(windows))]
+
+use std::fs;
+use std::process::Command;
+
+/// Put a regular file where the hooks directory has to go, so creating it
+/// cannot succeed. This is the shape the bug was reported in.
+fn occupy(path: &std::path::Path) {
+    fs::create_dir_all(path.parent().expect("parent")).expect("create parent");
+    fs::write(path, "not a directory").expect("occupy hooks path");
+}
+
+#[test]
+fn a_local_install_that_cannot_write_exits_non_zero() {
+    let repo = tempfile::tempdir().expect("temp repo");
+    let home = tempfile::tempdir().expect("temp home");
+    assert!(Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(repo.path())
+        .status()
+        .expect("git init")
+        .success());
+    // The hooks *directory* is fine; the hook file itself cannot be written,
+    // which is the case the old code printed and then swallowed.
+    fs::create_dir_all(repo.path().join(".git/hooks/post-commit")).expect("occupy hook path");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tokensave"))
+        .args(["githooks", "on", "--local"])
+        .current_dir(repo.path())
+        .env("HOME", home.path())
+        .env("USERPROFILE", home.path())
+        .output()
+        .expect("run tokensave githooks on --local");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "a failed local install must not exit 0. stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("could not install git hooks"),
+        "the failure has to say which hooks. stderr: {stderr}"
+    );
+}
+
+#[test]
+fn a_global_install_that_cannot_write_exits_non_zero() {
+    let home = tempfile::tempdir().expect("temp home");
+    let cwd = tempfile::tempdir().expect("temp cwd");
+    occupy(&home.path().join(".config/git/hooks"));
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tokensave"))
+        .args(["githooks", "on"])
+        .current_dir(cwd.path())
+        .env("HOME", home.path())
+        .env("USERPROFILE", home.path())
+        .env_remove("XDG_CONFIG_HOME")
+        .output()
+        .expect("run tokensave githooks on");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "a failed global install must not exit 0. stderr: {stderr}"
+    );
+}

--- a/tests/global_git_hooks_failure_test.rs
+++ b/tests/global_git_hooks_failure_test.rs
@@ -1,0 +1,29 @@
+//! `tokensave githooks on` (global, no `--local`) must not report success when
+//! it could not install anything.
+//!
+//! This file holds a single test on purpose: it overrides `HOME`, which is
+//! process-global, and cargo runs the tests inside one binary on threads.
+
+use tokensave::agents::{offer_git_post_commit_hook, GitHookMode};
+
+#[test]
+fn a_global_hook_install_that_cannot_proceed_is_reported_as_an_error() {
+    let home = tempfile::tempdir().expect("tempdir");
+
+    // Occupy `~/.config/git/hooks` with a *file*, so `create_dir_all` for the
+    // hooks directory cannot succeed. This is the real-world shape of the bug:
+    // the command prints a red ✘ and then exits 0.
+    let git_dir = home.path().join(".config").join("git");
+    std::fs::create_dir_all(&git_dir).expect("git config dir");
+    std::fs::write(git_dir.join("hooks"), "not a directory").expect("occupy hooks path");
+
+    std::env::set_var("HOME", home.path());
+    std::env::set_var("USERPROFILE", home.path());
+
+    let result = offer_git_post_commit_hook("/usr/bin/tokensave", GitHookMode::Yes);
+
+    assert!(
+        result.is_err(),
+        "a global hook install that installed nothing must report an error, got: {result:?}"
+    );
+}

--- a/tests/global_git_hooks_forwarder_failure_test.rs
+++ b/tests/global_git_hooks_forwarder_failure_test.rs
@@ -1,0 +1,44 @@
+//! A forwarder that could not be written must be reported too (#488).
+//!
+//! Claiming a global `core.hooksPath` disables every hook type in each repo's
+//! `.git/hooks/`, so tokensave drops pure forwarders for the hooks it does not
+//! own. Those writes print the same "Failed to create" line as the owned hooks,
+//! so leaving them out of the failure list reproduces the exact bug this issue
+//! is about: a printed failure and an exit code of 0.
+//!
+//! Single test on purpose: it overrides `HOME`, which is process-global.
+#![cfg(unix)]
+
+use tokensave::agents::{offer_git_post_commit_hook, GitHookMode};
+
+#[test]
+fn an_unwritable_forwarder_is_reported() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let hooks = home.path().join(".config").join("git").join("hooks");
+    std::fs::create_dir_all(&hooks).expect("create hooks dir");
+
+    // A dangling symlink: `exists()` follows it and reports false, so the
+    // forwarder is attempted, and the write then fails.
+    std::os::unix::fs::symlink(
+        home.path().join("gone").join("pre-commit"),
+        hooks.join("pre-commit"),
+    )
+    .expect("dangle pre-commit");
+
+    std::env::set_var("HOME", home.path());
+    std::env::set_var("USERPROFILE", home.path());
+
+    let result = offer_git_post_commit_hook("/usr/bin/tokensave", GitHookMode::Yes);
+
+    let message = result.expect_err("a forwarder that could not be written must be reported");
+    assert!(
+        message.contains("pre-commit"),
+        "the error must name the forwarder that failed, got: {message}"
+    );
+
+    // The hooks the user actually asked for still install.
+    assert!(
+        hooks.join("post-commit").is_file(),
+        "post-commit must still install"
+    );
+}

--- a/tests/global_git_hooks_partial_failure_test.rs
+++ b/tests/global_git_hooks_partial_failure_test.rs
@@ -1,0 +1,43 @@
+//! One hook failing to write must not stop the other two from installing, and
+//! must still be reported.
+//!
+//! Single test on purpose: it overrides `HOME`, which is process-global, and
+//! cargo runs the tests inside one binary on threads.
+
+use tokensave::agents::{offer_git_post_commit_hook, GitHookMode};
+
+#[test]
+fn one_unwritable_hook_is_reported_and_the_others_still_install() {
+    let home = tempfile::tempdir().expect("tempdir");
+
+    // The hooks directory itself is fine, but `post-commit` is occupied by a
+    // directory, so opening it for writing fails on both Unix and Windows.
+    let hooks = home.path().join(".config").join("git").join("hooks");
+    std::fs::create_dir_all(hooks.join("post-commit")).expect("occupy hook path");
+
+    std::env::set_var("HOME", home.path());
+    std::env::set_var("USERPROFILE", home.path());
+
+    let result = offer_git_post_commit_hook("/usr/bin/tokensave", GitHookMode::Yes);
+
+    assert!(
+        result.is_err(),
+        "the hook that could not be written must be reported, got: {result:?}"
+    );
+    let message = result.unwrap_err();
+    assert!(
+        message.contains("post-commit"),
+        "the error must name the hook that failed, got: {message}"
+    );
+
+    // The whole point of collecting failures instead of returning on the first
+    // one: the other two hooks the user asked for still get installed.
+    assert!(
+        hooks.join("post-checkout").is_file(),
+        "post-checkout must still install after post-commit failed"
+    );
+    assert!(
+        hooks.join("post-merge").is_file(),
+        "post-merge must still install after post-commit failed"
+    );
+}

--- a/tests/local_git_hooks_test.rs
+++ b/tests/local_git_hooks_test.rs
@@ -156,3 +156,31 @@ fn a_directory_that_is_not_a_repository_is_an_error_not_a_silent_success() {
     assert!(install_local_git_hooks(dir.path(), "/usr/bin/tokensave").is_err());
     assert!(!local_git_hooks_present(dir.path()));
 }
+
+#[test]
+fn a_hook_that_cannot_be_written_is_reported_as_failed() {
+    let dir = repo();
+    let hooks = repo_hooks_dir(dir.path()).expect("hooks dir");
+    // A directory where the hook file belongs: the path exists, so the append
+    // branch is taken, and opening a directory for writing fails on both Unix
+    // and Windows.
+    std::fs::create_dir_all(hooks.join("post-commit")).expect("occupy hook path");
+
+    let out = install_local_git_hooks(dir.path(), "/usr/bin/tokensave").expect("install");
+
+    assert_eq!(
+        out.failed,
+        vec!["post-commit"],
+        "a hook that could not be written must be reported, not silently dropped"
+    );
+    assert!(
+        !out.installed.contains(&"post-commit".to_string()),
+        "a failed hook must not be listed as installed, got: {:?}",
+        out.installed
+    );
+    assert_eq!(
+        out.installed,
+        vec!["post-checkout", "post-merge"],
+        "the other two hooks must still install"
+    );
+}


### PR DESCRIPTION
Fixes #488

Both paths printed a red `✘ Failed to open … for writing` and then exited 0, so a setup script gating on the exit code carried on with no hooks installed and no way to tell.

- The **global** path called `write_global_hook`, which returns a `bool`, in an `if` with no `else`.
- The **local** path collected `installed` and `already_present`, but had nowhere to put a hook whose write failed.

## The change

`offer_git_post_commit_hook` returns `Result<(), String>`; `LocalHookInstall` gains a `failed` list; `githooks on` turns either into a non-zero exit naming the hooks.

Failures are **collected**, not raised at the first one — the command installs three hooks, and bailing early would skip the two the user also asked for. The specific reason is still printed where it happens; the returned message only exists so the process can exit non-zero.

What deliberately stays a success:

| case | result |
|---|---|
| user declines the prompt | `Ok` |
| hook already present | `Ok` |
| hook write fails during `install` | `Ok` — best-effort (`let _ =`), a hook must not fail a whole install |
| explicit `githooks on` could not write a hook | **`Err`, non-zero exit** |

## Tests

`tests/githooks_exit_code_test.rs` runs the binary, because the bug was the wiring: the library could know perfectly well that the write failed and the process still exited 0. Both tests are red against unfixed `src/` and green with it.

Library-level: `local_git_hooks_test` (the `failed` list is populated), `global_git_hooks_failure_test` (nothing installable → `Err`), `global_git_hooks_partial_failure_test` (one unwritable hook, the other two still install). Each was verified fail-first by neutering *its own* code path while keeping the signature, so a compile error isn't being mistaken for a red test.

`cargo test` clean across the suite, `cargo fmt --check` clean, `cargo clippy --all-targets` produces no new warnings.

Independent of #487 and #485 in code — different files, based on `master`. The one overlap is the CHANGELOG: both this and #487 add a `### Fixed` section under `[Unreleased]` at the same anchor, so whichever lands first, I'll rebase the other onto it.
