### PR TITLE
feat: add cargo-binstall support for prebuilt binary installation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,29 @@ exclude = [
     ".worktrees/",
 ]
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target-arch }-{ target-family }{ archive-suffix }"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.aarch64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-aarch64-macos.tar.gz"
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-x86_64-linux.tar.gz"
+
+[package.metadata.binstall.overrides.aarch64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-aarch64-linux.tar.gz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-x86_64-windows.zip"
+pkg-fmt = "zip"
+
+[package.metadata.binstall.overrides.aarch64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-aarch64-windows.zip"
+pkg-fmt = "zip"
+
+
 [features]
 default = ["full"]
 

--- a/README.md
+++ b/README.md
@@ -103,9 +103,13 @@ scoop bucket add tokensave https://github.com/aovestdipaperino/scoop-bucket
 scoop install tokensave
 ```
 
-**Cargo (any platform):**
+**Cargo / cargo-binstall (any platform):**
 
 ```bash
+# Fast install prebuilt binary without compiling:
+cargo binstall tokensave
+
+# Or compile from source:
 cargo install tokensave                          # full (50+ languages, default)
 cargo install tokensave --features medium        # medium tier
 cargo install tokensave --no-default-features    # lite (smallest binary)


### PR DESCRIPTION
### Summary
This PR adds `[package.metadata.binstall]` to `Cargo.toml` and documents `cargo binstall tokensave` in the README.

### Details
- Maps `tokensave` precompiled release assets (`aarch64-macos`, `x86_64-linux`, `aarch64-linux`, `x86_64-windows`, `aarch64-windows`) directly to `cargo-binstall` target triples.
- Allows users and developers to install `tokensave` in ~1-2 seconds via `cargo binstall tokensave` without requiring a local Rust toolchain compilation step.
- Verified with `cargo binstall --dry-run --force --manifest-path Cargo.toml tokensave`.