### PR TITLE
feat(indexing): track Terraform/OpenTofu dependency lockfiles as artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project uses [maintenance-based versioning](TOKENSAVE-VERSIONING.md), n
 
 ## [Unreleased]
 
+### Added
+- **Terraform/OpenTofu dependency lockfiles are indexed as artifacts.** `.terraform.lock.hcl` (the basename both tools share) was dropped twice over: the hidden-entry filter skips dot-prefixed names, and no extractor or artifact extension owns `.hcl`, so sync reported it as an unsupported file and neither `tokensave_files` nor literal search could reach the provider source addresses, selected versions, and checksums it records. Classification is by exact basename, not extension: claiming `.hcl` outright would mislabel every other HCL document (Packer, Consul, Vault, Nomad) as Terraform source. The lockfile rides the existing artifact pipeline (#323): a `files` row with hash, size, and mtime, never parsed, so checksum strings cannot surface as symbols, and findable by path and by literal content search for both `registry.terraform.io/...` and `registry.opentofu.org/...` provider addresses. Other HCL files still count in the unsupported-extension summary, and other hidden files stay excluded.
+
 ### Changed
 - **Test and dev profiles now use `debug = "line-tables-only"`.** Across tokensave's 162+ integration-test crates, default debuginfo (`debug = 2`) generated up to ~395 MiB per test binary, driving `target/` peak disk usage past 25–29 GB during multi-threaded test links. Tuning `debug = "line-tables-only"` slashes test binary sizes by ~45% (down to ~216 MiB per test binary) and reduces peak disk footprint during test builds while preserving full file:line numbers in backtraces, panic messages, and test assertion locations.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -585,6 +585,29 @@ pub fn resolve_path_with_discovery(path: Option<String>) -> PathBuf {
     }
 }
 
+/// Basename of the dependency lockfile Terraform and `OpenTofu` share.
+///
+/// `OpenTofu` kept Terraform's lockfile name and format, so one basename
+/// covers both tools; the provider registry address inside may be either
+/// `registry.terraform.io/...` or `registry.opentofu.org/...`.
+pub const TERRAFORM_LOCKFILE_BASENAME: &str = ".terraform.lock.hcl";
+
+/// Returns `true` when `path` is a Terraform/OpenTofu dependency lockfile.
+///
+/// The lockfile is the one dot-prefixed, HCL-formatted file a project is
+/// expected to commit and diff, so it is indexed as a path-tracked artifact
+/// even though the scanner's hidden filter and the unsupported `.hcl`
+/// extension would each otherwise drop it. Classification is by exact
+/// basename rather than extension: claiming `hcl` outright would mislabel
+/// every other HCL document (Packer, Consul, Vault, Nomad, Waypoint) as
+/// Terraform source, and an artifact is never parsed, so checksum-heavy
+/// content cannot surface as symbols.
+pub fn is_dependency_lockfile(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == TERRAFORM_LOCKFILE_BASENAME)
+}
+
 /// Returns `true` if the path matches any of the configured `include` patterns.
 ///
 /// This is used to allow hidden (dot-prefixed) directories that would

--- a/src/tokensave/indexing.rs
+++ b/src/tokensave/indexing.rs
@@ -1585,6 +1585,12 @@ impl TokenSave {
                 }
                 let name = e.file_name().to_string_lossy();
                 if name.starts_with('.') || name == "target" {
+                    // The dependency lockfile is the one hidden file admitted
+                    // without an include glob: committed by convention and
+                    // classified as an artifact by basename downstream.
+                    if !e.file_type().is_dir() && crate::config::is_dependency_lockfile(e.path()) {
+                        return true;
+                    }
                     // Allow if the relative path matches an include glob or a
                     // manifest entry (#194).
                     if let Ok(rel) = e.path().strip_prefix(root) {
@@ -1630,9 +1636,10 @@ impl TokenSave {
     /// additionally treat every `.gitignore` it encounters as a standalone
     /// ignore file, ensuring nested rules are applied even outside a git repo.
     ///
-    /// When `include` globs are configured, the crate's built-in hidden filter
-    /// is disabled and hidden entries are filtered manually so that included
-    /// dot-paths can pass through.
+    /// The crate's built-in hidden filter is disabled and hidden entries are
+    /// filtered manually instead (directories pruned in `filter_entry`, files
+    /// skipped in the walk loop), so that include globs, manifest entries,
+    /// and the dependency lockfile basename can admit specific dot-paths.
     pub(crate) fn scan_files_with_gitignore(
         &self,
         supported_exts: &[&str],
@@ -1640,8 +1647,13 @@ impl TokenSave {
     ) -> Vec<String> {
         let manifest = self.manifest();
         // Manifest entries behave like include globs for hidden-path
-        // filtering, so disable the crate's hidden filter when either exists.
-        let has_includes = !self.config.include.is_empty() || manifest.is_some();
+        // filtering, so the crate's hidden filter is disabled when either
+        // exists — and unconditionally now that the dependency lockfile is
+        // admitted by basename: the crate-level `hidden(true)` filter drops
+        // dot-prefixed entries before `filter_entry` can see them, so the
+        // lockfile exemption below could never run. Hidden-entry semantics
+        // are preserved manually: directories are pruned in `filter_entry`,
+        // files are skipped in the walk loop.
         let mut files = Vec::new();
         // Prune directories covered by an `exclude` glob *before* descending.
         // The `ignore` crate honors `.gitignore` but not our `config.exclude`,
@@ -1653,9 +1665,10 @@ impl TokenSave {
         let root = self.project_root.clone();
         let config = self.config.clone();
         let canonical_root = self.project_root.canonicalize().ok();
+        let manifest_for_prune = manifest.clone();
         let walker = ignore::WalkBuilder::new(&self.project_root)
             .follow_links(true)
-            .hidden(!has_includes) // disable when we need to check includes
+            .hidden(false) // hidden entries are filtered manually below
             .git_ignore(true)
             .git_global(true)
             .git_exclude(true)
@@ -1666,6 +1679,22 @@ impl TokenSave {
                     if let Ok(rel) = e.path().strip_prefix(&root) {
                         let rel_str = rel.to_string_lossy().replace('\\', "/");
                         if is_excluded_dir(&rel_str, &config) {
+                            return false;
+                        }
+                    }
+                    // Hidden directories stay pruned exactly as the crate's
+                    // disabled hidden filter pruned them; an include glob or
+                    // manifest entry re-admits one (#194).
+                    if e.depth() > 0 && e.file_name().to_string_lossy().starts_with('.') {
+                        let rel_str = e
+                            .path()
+                            .strip_prefix(&root)
+                            .map(|rel| rel.to_string_lossy().replace('\\', "/"))
+                            .unwrap_or_default();
+                        let manifest_allows = manifest_for_prune.as_deref().is_some_and(|m| {
+                            m.matches_local_file(&rel_str) || m.local_dir_may_contain(&rel_str)
+                        });
+                        if !is_included(&rel_str, &config) && !manifest_allows {
                             return false;
                         }
                     }
@@ -1690,11 +1719,14 @@ impl TokenSave {
                 continue;
             };
 
-            // When we disabled the crate's hidden filter, manually skip hidden
-            // entries that don't match an include glob.
-            if has_includes && entry.depth() > 0 {
+            // The crate's hidden filter is disabled (see above), so hidden
+            // files are skipped manually unless an include glob or manifest
+            // entry admits them — with one exemption: the dependency
+            // lockfile, admitted by basename so it can be tracked as an
+            // artifact without an include glob.
+            if entry.depth() > 0 && ft.is_file() {
                 let name = entry.file_name().to_string_lossy();
-                if name.starts_with('.') {
+                if name.starts_with('.') && !crate::config::is_dependency_lockfile(entry.path()) {
                     if let Ok(rel) = entry.path().strip_prefix(&self.project_root) {
                         let rel_str = rel.to_string_lossy().replace('\\', "/");
                         let manifest_allows = manifest.as_deref().is_some_and(|m| {
@@ -1742,7 +1774,12 @@ impl TokenSave {
             let manifest_match = self
                 .manifest()
                 .is_some_and(|m| m.matches_local_file(&rel_str));
-            if !manifest_match {
+            // Dependency lockfiles are admitted by basename (#497 follow-up):
+            // `.terraform.lock.hcl` is tracked as an artifact even though no
+            // extractor or artifact extension owns `.hcl`, and it must not
+            // count toward the unsupported-extension summary.
+            let lockfile_match = crate::config::is_dependency_lockfile(path);
+            if !manifest_match && !lockfile_match {
                 if !ext.is_empty() && !is_excluded(&rel_str, &self.config) {
                     let ext_lower = ext.to_ascii_lowercase();
                     if !NON_SOURCE_EXTS.contains(&ext_lower.as_str()) {
@@ -1957,15 +1994,22 @@ impl TokenSave {
     /// Artifacts are never handed to the extractor: they have no symbols by
     /// definition, and routing them through extraction would mean teaching both
     /// the in-process and subprocess paths to return an empty result.
+    ///
+    /// A path is an artifact when its extension is configured as one or when
+    /// its basename names a dependency lockfile (`is_dependency_lockfile`):
+    /// the lockfile's `.hcl` extension is deliberately not an artifact
+    /// extension, since that would classify every HCL document as one.
     pub(crate) fn partition_artifacts(
         files: Vec<String>,
         artifact_exts: &[String],
     ) -> (Vec<String>, Vec<String>) {
         files.into_iter().partition(|path| {
-            !std::path::Path::new(path)
-                .extension()
-                .and_then(|ext| ext.to_str())
-                .is_some_and(|ext| artifact_exts.contains(&ext.to_ascii_lowercase()))
+            let path_ref = std::path::Path::new(path);
+            !crate::config::is_dependency_lockfile(path_ref)
+                && !path_ref
+                    .extension()
+                    .and_then(|ext| ext.to_str())
+                    .is_some_and(|ext| artifact_exts.contains(&ext.to_ascii_lowercase()))
         })
     }
 

--- a/tests/lockfile_indexing_test.rs
+++ b/tests/lockfile_indexing_test.rs
@@ -1,0 +1,246 @@
+//! Terraform/OpenTofu dependency lockfiles must be indexed as artifacts.
+//!
+//! `.terraform.lock.hcl` (the basename Terraform and OpenTofu share) holds the
+//! resolved provider source addresses, selected versions, and checksums of an
+//! infrastructure tree. It is committed by convention, but the scanner dropped
+//! it twice over: the hidden-entry filter skips dot-prefixed names, and no
+//! extractor or artifact extension owns `.hcl`, so sync reported it as an
+//! unsupported file and neither `tokensave_files` nor literal search could
+//! reach it.
+//!
+//! The lockfile is classified by exact basename as a path-tracked artifact:
+//! never parsed, so checksum strings cannot surface as symbols, and other
+//! HCL documents (Packer, Consul, Vault) stay unsupported rather than being
+//! mislabelled as Terraform source.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::fs;
+
+use tempfile::TempDir;
+use tokensave::config::{load_config, save_config};
+use tokensave::tokensave::TokenSave;
+use tokensave::types::FileKind;
+
+const LOCKFILE: &str = r#"# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.82.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:examplehashAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+    "zh:0a8efb3775a13613bce5270696ce350947ebdf1ce5bf956aea95923db0a30036",
+  ]
+}
+
+provider "registry.opentofu.org/timofurrer/desec" {
+  version     = "0.6.2"
+  constraints = "0.6.2"
+  hashes = [
+    "h1:otherexamplehashBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=",
+  ]
+}
+"#;
+
+/// A project with Terraform source, a nested lockfile, and a non-lock HCL
+/// file, indexed with the default (gitignore-aware) scanner.
+async fn fixture() -> (TempDir, TokenSave) {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    fs::create_dir_all(project.join("infra/terraform")).unwrap();
+    fs::create_dir_all(project.join("packer")).unwrap();
+
+    fs::write(
+        project.join("infra/terraform/versions.tf"),
+        "terraform {\n  required_version = \">= 1.6\"\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("infra/terraform/.terraform.lock.hcl"),
+        LOCKFILE,
+    )
+    .unwrap();
+    fs::write(
+        project.join("packer/consul.hcl"),
+        "acl {\n  enabled = true\n}\n",
+    )
+    .unwrap();
+
+    let cg = TokenSave::init(project).await.unwrap();
+    cg.index_all().await.unwrap();
+    (dir, cg)
+}
+
+async fn paths(cg: &TokenSave) -> Vec<String> {
+    let mut out: Vec<String> = cg
+        .get_all_files()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|f| f.path)
+        .collect();
+    out.sort();
+    out
+}
+
+#[tokio::test]
+async fn lockfile_is_indexed_despite_hidden_name_and_unsupported_extension() {
+    // The reported symptom: sync succeeded, the skipped summary counted one
+    // unsupported `.hcl` file, and the lockfile was absent from the file list.
+    let (_dir, cg) = fixture().await;
+    let paths = paths(&cg).await;
+    assert!(
+        paths.contains(&"infra/terraform/.terraform.lock.hcl".to_string()),
+        "the lockfile must be discoverable by path, got: {paths:?}"
+    );
+}
+
+#[tokio::test]
+async fn lockfile_is_an_artifact_with_no_symbols() {
+    // Artifact, not source: parsed HCL would turn provider checksums into
+    // nodes, and a lockfile has no symbols to begin with.
+    let (_dir, cg) = fixture().await;
+    let files = cg.get_all_files().await.unwrap();
+    let lock = files
+        .iter()
+        .find(|f| f.path == "infra/terraform/.terraform.lock.hcl")
+        .expect("lockfile must be indexed");
+    assert_eq!(lock.kind, FileKind::Artifact);
+    assert_eq!(lock.node_count, 0, "a lockfile is never parsed");
+    assert!(!lock.content_hash.is_empty());
+    assert!(lock.size > 0);
+    assert!(lock.modified_at > 0);
+}
+
+#[tokio::test]
+async fn non_lock_hcl_files_stay_unsupported() {
+    // Basename classification, not extension claiming: a Consul/Packer-style
+    // `.hcl` document must not become an artifact or a source file, and the
+    // unsupported-extension accounting must keep seeing it.
+    let (_dir, cg) = fixture().await;
+    let paths = paths(&cg).await;
+    assert!(
+        !paths.contains(&"packer/consul.hcl".to_string()),
+        "a non-lock .hcl file must not be tracked, got: {paths:?}"
+    );
+
+    let result = cg.sync().await.unwrap();
+    assert!(
+        result
+            .skipped_extensions
+            .iter()
+            .any(|(ext, count)| ext == "hcl" && *count == 1),
+        "the non-lock .hcl file must still count as skipped, got: {:?}",
+        result.skipped_extensions
+    );
+    // Exactly one `.hcl` file exists on disk (the non-lock one) and it alone
+    // accounts for the count: the lockfile must not add to it.
+}
+
+#[tokio::test]
+async fn lockfile_content_is_searchable_by_literal_scan() {
+    // Literal search reads every indexed file's bytes, so both registry
+    // address forms must be findable once the row exists.
+    let (_dir, cg) = fixture().await;
+    let files = cg.get_all_files().await.unwrap();
+    let lock = files
+        .iter()
+        .find(|f| f.path == "infra/terraform/.terraform.lock.hcl")
+        .unwrap();
+    let source = fs::read_to_string(cg.project_root().join(&lock.path)).unwrap();
+    assert!(source.contains("registry.terraform.io/hashicorp/aws"));
+    assert!(source.contains("registry.opentofu.org/timofurrer/desec"));
+}
+
+#[tokio::test]
+async fn sync_picks_up_a_newly_written_lockfile() {
+    // Projects that ran `terraform init` after their first index must gain
+    // the lockfile on an incremental sync, not just a full reindex.
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    fs::create_dir_all(project.join("infra/terraform")).unwrap();
+    fs::write(
+        project.join("infra/terraform/versions.tf"),
+        "terraform {}\n",
+    )
+    .unwrap();
+
+    let cg = TokenSave::init(project).await.unwrap();
+    cg.index_all().await.unwrap();
+    assert!(
+        !paths(&cg)
+            .await
+            .contains(&"infra/terraform/.terraform.lock.hcl".to_string()),
+        "no lockfile yet"
+    );
+
+    fs::write(
+        project.join("infra/terraform/.terraform.lock.hcl"),
+        LOCKFILE,
+    )
+    .unwrap();
+    cg.sync().await.unwrap();
+
+    let paths = paths(&cg).await;
+    assert!(
+        paths.contains(&"infra/terraform/.terraform.lock.hcl".to_string()),
+        "sync must pick up the new lockfile, got: {paths:?}"
+    );
+}
+
+#[tokio::test]
+async fn lockfile_is_found_without_gitignore_support() {
+    // The walkdir scanner (git_ignore = false) applies its own hidden-entry
+    // filter; the lockfile exemption must hold there too.
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    fs::create_dir_all(project.join("infra/terraform")).unwrap();
+    fs::write(
+        project.join("infra/terraform/.terraform.lock.hcl"),
+        LOCKFILE,
+    )
+    .unwrap();
+
+    TokenSave::init(project).await.unwrap();
+    let mut config = load_config(project).unwrap();
+    config.git_ignore = false;
+    save_config(project, &config).unwrap();
+    let cg = TokenSave::open(project).await.unwrap();
+    cg.index_all().await.unwrap();
+
+    let paths = paths(&cg).await;
+    assert!(
+        paths.contains(&"infra/terraform/.terraform.lock.hcl".to_string()),
+        "walkdir scan must find the lockfile, got: {paths:?}"
+    );
+}
+
+#[tokio::test]
+async fn other_hidden_files_remain_excluded() {
+    // The lockfile exemption must not widen hidden-file handling generally.
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    fs::create_dir_all(project.join("infra/terraform")).unwrap();
+    fs::write(
+        project.join("infra/terraform/.terraform.lock.hcl"),
+        LOCKFILE,
+    )
+    .unwrap();
+    fs::write(project.join("infra/terraform/.env"), "SECRET=nope\n").unwrap();
+    fs::write(project.join("infra/terraform/.notes.md"), "hidden\n").unwrap();
+
+    let cg = TokenSave::init(project).await.unwrap();
+    cg.index_all().await.unwrap();
+
+    let paths = paths(&cg).await;
+    assert!(paths.contains(&"infra/terraform/.terraform.lock.hcl".to_string()));
+    assert!(
+        !paths.contains(&"infra/terraform/.env".to_string()),
+        "hidden files must stay excluded, got: {paths:?}"
+    );
+    assert!(
+        !paths.contains(&"infra/terraform/.notes.md".to_string()),
+        "hidden files must stay excluded even with a tracked extension, got: {paths:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Indexes `.terraform.lock.hcl`, the dependency lockfile Terraform and OpenTofu write under the same basename, as a path-tracked artifact: a `files` row with content hash, size, and mtime, never parsed.
- The lockfile becomes discoverable through `tokensave_files` and its content (provider source addresses, selected versions, checksums) through literal search, for both `registry.terraform.io/...` and `registry.opentofu.org/...` address forms.
- Classification is by exact basename, not by claiming the `.hcl` extension, so other HCL documents (Packer, Consul, Vault, Nomad, Waypoint) keep their current unsupported-extension reporting and are not mislabelled as Terraform source.

## Motivation

Fixes #520. Follow-up to the Terraform extractor merged in #497. The Terraform extractor indexes `versions.tf` and friends, but the lockfile holding the resolved provider evidence was dropped twice over: the scanner's hidden-entry filter skips dot-prefixed names, and no extractor or artifact extension owns `.hcl`, so `tokensave sync` reported it as an unsupported file and no query surface could reach it. An agent could read the requested version constraint but never confirm which provider version the project actually resolved.

## Changes

- `src/config.rs`: new `TERRAFORM_LOCKFILE_BASENAME` constant and `is_dependency_lockfile()` basename classifier, shared by the scanner and the artifact partition.
- `src/tokensave/indexing.rs`, `accept_file`: a file whose extension has no registered extractor is now also admitted when its basename is the dependency lockfile; the basename match exempts it from the unsupported-extension tally, so a project whose only `.hcl` file is the lockfile no longer reports `.hcl (1)` skipped.
- `src/tokensave/indexing.rs`, both scan walkers: the hidden-entry filters gain a single-file exemption for the lockfile basename. In the gitignore walker this required disabling the `ignore` crate's `hidden(true)` pre-filter, which drops dot-prefixed entries before `filter_entry` can see them; hidden-entry semantics are preserved manually, with directories pruned in `filter_entry` and files skipped in the walk loop, so every other hidden path behaves exactly as before.
- `src/tokensave/indexing.rs`, `partition_artifacts`: basename-classified lockfiles partition as artifacts alongside the configured artifact extensions, so they ride the existing add/modify/remove lifecycle (#323) with no extractor involvement and no symbol rows for checksum strings.
- `tests/lockfile_indexing_test.rs`: seven regression tests covering indexing, artifact kind, non-lock `.hcl` rejection with intact skipped-extension counts, both walker modes, incremental-sync pickup, and continued exclusion of other hidden files.
- `CHANGELOG.md` entry under `[Unreleased]`.

Non-goals, stated so review does not have to guess: no provider/version symbol nodes (an artifact is never parsed, which is also what keeps checksum strings out of the symbol tables), no `terraform.tfstate` handling (state files can carry secrets and stay untouched), and no change to `tokensave_context` ranking, which is symbol-based and has the same contract for every artifact kind; the retrieval surfaces for artifacts are `tokensave_files` and literal search. Literal search over a selected `graph_branch` reads working-tree bytes, a pre-existing caveat for any file; local and `graph_root` queries are unaffected.

## Test plan

- [x] `cargo test` passes
- [x] `cargo clippy` has no new warnings
- [x] Tested manually (describe below if applicable)

New regression coverage in `tests/lockfile_indexing_test.rs` (7 tests):

| test | pins |
| --- | --- |
| `lockfile_is_indexed_despite_hidden_name_and_unsupported_extension` | the reported symptom |
| `lockfile_is_an_artifact_with_no_symbols` | artifact kind, hash/size/mtime present, zero nodes |
| `non_lock_hcl_files_stay_unsupported` | `consul.hcl` untracked, `.hcl` still counted as skipped exactly once |
| `lockfile_content_is_searchable_by_literal_scan` | both registry address forms present in the indexed file's bytes |
| `sync_picks_up_a_newly_written_lockfile` | incremental sync path, not just full reindex |
| `lockfile_is_found_without_gitignore_support` | walkdir scanner (`git_ignore = false`) hidden exemption |
| `other_hidden_files_remain_excluded` | exemption does not widen hidden-file handling |

Existing suites touching the modified scan paths all pass: `artifact_indexing_test` (9), `warn_skipped_hidden_dirs_test`, `gitignore_without_git_repo_test` (6), `hook_include_glob_test` (4), `literal_search_unscanned_test` (5), `skipped_summary_cli_test` (9), `integration_test` (34), `mcp_handler_test` (197).

Real-project proof: on a private infrastructure repository that migrated from Terraform to OpenTofu, with `infra/terraform/.terraform.lock.hcl` committed, the released binary reports `Skipped 7 tracked files (unsupported extension): .j2 (3), .bats (2), .hcl (1), .html (1)` and the lockfile is absent from the index. With this branch's binary, `tokensave sync` reports `.j2 (3), .bats (2), .html (1)` (the `.hcl` entry is gone, with no warning for the lockfile), and the lockfile row is present:

```text
$ tokensave sync
sync done - 1 added, 0 modified, 0 removed
Skipped 6 tracked files (unsupported extension): .j2 (3), .bats (2), .html (1)

$ tokensave tool files --pattern '**/.terraform.lock.hcl'
infra/terraform/.terraform.lock.hcl  artifact

$ tokensave tool search 'registry.terraform.io' --literal
infra/terraform/.terraform.lock.hcl:4  provider "registry.terraform.io/..." {
```

<details>

<summary>Gate output</summary>

```text
cargo fmt --all -- --check    # clean
cargo clippy --workspace --all-targets    # no new warnings
cargo test --test lockfile_indexing_test    # 7 passed
cargo test --test artifact_indexing_test --test warn_skipped_hidden_dirs_test \
  --test gitignore_without_git_repo_test --test hook_include_glob_test \
  --test literal_search_unscanned_test --test skipped_summary_cli_test    # 34 passed
cargo test --test integration_test    # 34 passed
cargo test --test mcp_handler_test    # 197 passed
```

</details>

## Checklist

- [x] `CHANGELOG.md` updated (under `[Unreleased]` if no version bump)
- [x] No secrets, credentials, or `.env` files included
- [x] Breaking changes documented (if any)

No breaking changes: the diff only admits one previously skipped basename into the artifact pipeline; every other path through the scanner, the skipped-extension accounting, and the hidden-file filters is unchanged.
