### PR TITLE
test(resolution): pin the bare-name gate in the production → production direction (#536)

### DIFF
--- a/tests/bare_name_reachability_test.rs
+++ b/tests/bare_name_reachability_test.rs
@@ -150,3 +150,64 @@ async fn a_rust_bare_name_across_modules_is_not_gated() {
         "Rust bare-name resolution must be unaffected by the gate"
     );
 }
+
+/// The measured shape, with neither end in a test tree: a closure named `p`
+/// nested inside a method is the only symbol of that name in the project, and
+/// an ordinary local named `p` sits in a different production package that
+/// imports nothing from it.
+#[tokio::test]
+async fn a_python_bare_name_does_not_bind_to_an_unreachable_production_candidate() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("ui")).unwrap();
+    std::fs::create_dir_all(root.join("util")).unwrap();
+
+    std::fs::write(
+        root.join("ui/panel.py"),
+        "import tkinter as tk\n\n\nclass Panel:\n    def writers(self):\n        t = self._txt\n\n        def p(s):\n            t.insert(tk.END, s + \"\n\")\n\n        return p\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("util/paths.py"),
+        "import os\n\n\ndef cache_dir(root):\n    p = os.path.join(root, \".cache\")\n    os.makedirs(p, exist_ok=True)\n    return p\n",
+    )
+    .unwrap();
+
+    let cg = TokenSave::init(root).await.unwrap();
+    cg.sync().await.unwrap();
+
+    assert!(
+        !has_edge(&cg, "util/paths.py", "p", "ui/panel.py").await,
+        "a local name must not bind to an unreachable closure in another production module"
+    );
+}
+
+/// The recall control, same shape: an explicit import is evidence, so the edge
+/// must survive. Without this the test above could be satisfied by a rule that
+/// simply refuses all cross-package bare names.
+#[tokio::test]
+async fn a_python_bare_name_still_binds_across_production_modules_when_imported() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("ui")).unwrap();
+    std::fs::create_dir_all(root.join("util")).unwrap();
+
+    std::fs::write(
+        root.join("ui/widgets.py"),
+        "def render_banner():\n    return \"banner\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("util/report.py"),
+        "from ui.widgets import render_banner\n\n\ndef build():\n    return render_banner()\n",
+    )
+    .unwrap();
+
+    let cg = TokenSave::init(root).await.unwrap();
+    cg.sync().await.unwrap();
+
+    assert!(
+        has_edge(&cg, "util/report.py", "render_banner", "ui/widgets.py").await,
+        "an explicitly imported cross-package name must still resolve"
+    );
+}


### PR DESCRIPTION
Test-only. No production code, no behaviour change — #533 already handles this
case correctly. What is missing is coverage.

## What is uncovered

#533 removed **1,216** edges on a 515-file Python project. Only **731** crossed
into `tests/`; the other **485** ran production → production, where a
production → `tests/` metric cannot see them. The largest single target was a
closure `def p(s)` nested inside a method, which 218 sites acquired a `uses` edge
to purely because it was the only symbol named `p` in the project. Measured in
#536.

Both tests written for this defect class build the phantom as `src/` → `tests/`:
`python_phantom_call_edges_test` (#503) uses a `logging.Logger` and a test double
defining `info`; `bare_name_reachability_test` (#522) uses a pytest fixture named
`exe`. Neither puts both ends in production.

The collision that generates these is not specific to test trees — `p`, `total`,
`files`, `right` are what a nested helper gets called anywhere.

## That it is uncovered is measured, not asserted

`97f32fe` (the parent of #533) is green across **all 171 test targets**, and the
phantom test below **fails** on that same commit. If anything existing pinned this
direction, that baseline could not have been green.

```
97f32fe  a_python_bare_name_does_not_bind_to_an_unreachable_production_candidate ... FAILED
         a_python_bare_name_still_binds_across_production_modules_when_imported ... ok
master   6 passed; 0 failed
```

## The two cases

`a_python_bare_name_does_not_bind_to_an_unreachable_production_candidate` — the
measured shape with neither end in a test tree: a closure named `p` nested inside a
method is the sole symbol of that name, and an ordinary local `p` sits in a
different production package importing nothing from it.

`a_python_bare_name_still_binds_across_production_modules_when_imported` — the
recall control. Without it the first test would also be satisfied by a rule
refusing every cross-package bare name, which would be a worse defect than the one
being guarded. This is the same before/after property the existing three controls
have, and the reason they are there.

Appended to `bare_name_reachability_test.rs` rather than added as a new target, so
they reuse its `has_edge` helper verbatim. 61 insertions, 0 deletions.

## Gates

* `cargo fmt --all -- --check` — clean
* `cargo test --test bare_name_reachability_test` — 6 passed, 0 failed
* `cargo clippy --workspace --all-targets` — exit 0, **no new warnings**. Master
  currently carries 12, all in `src/` (`upgrade.rs`, `tokensave/guard.rs`,
  `resolution/variants.rs`, `mcp/transport.rs`, `db/queries/edges.rs`,
  `agents/fs.rs`); none reference the file this touches, which is the only file
  changed.

Built and run on Windows 11, `rustc 1.98.1` MSVC — so this is also a second
platform for #533's suite, which came back 172 targets / 3,747 tests / 0 failures.

Closes nothing on its own; it is the coverage half of #536.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
