### PR TITLE
feat(upgrade): verify the downloaded release binary against a published SHA256SUMS (#525)

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -94,6 +94,21 @@ jobs:
         shell: bash
         run: gh release upload ${{ github.ref_name }} tokensave-beta-${{ github.ref_name }}-${{ matrix.name }}.${{ matrix.archive }} --clobber
 
+      # Hash the exact bytes that were just uploaded, on the leg that produced
+      # them (#525). Collected into a single SHA256SUMS by the checksums job
+      # below, which `tokensave upgrade` verifies against before extracting.
+      - name: Record archive SHA256
+        shell: bash
+        run: |
+          ASSET="tokensave-beta-${{ github.ref_name }}-${{ matrix.name }}.${{ matrix.archive }}"
+          sha256sum "$ASSET" > "${ASSET}.sha256"
+
+      - name: Upload checksum artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: checksum-beta-${{ matrix.name }}
+          path: "*.sha256"
+
       # --- Homebrew bottle (only for platforms with bottle_tag) ---
 
       - name: Package Homebrew bottle
@@ -112,6 +127,37 @@ jobs:
         with:
           name: bottle-beta-${{ matrix.bottle_tag }}
           path: "tokensave-beta-*.bottle.tar.gz"
+
+  # Publishes the SHA256SUMS asset `tokensave upgrade` verifies against (#525).
+  # Runs after every build leg so the file covers all platforms: upgrade fails
+  # closed on a missing hash, so a sums file that omits a platform would block
+  # upgrades for it rather than silently skipping verification.
+  checksums:
+    name: Publish SHA256SUMS
+    if: env.BETA_CHANNEL_ENABLED == 'true' && github.event.release.prerelease
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download checksum artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: checksum-beta-*
+          path: checksums
+          merge-multiple: true
+
+      - name: Assemble SHA256SUMS
+        run: |
+          # Sorted so the file is byte-stable regardless of leg completion
+          # order, which keeps a re-run from producing a different asset.
+          cat checksums/*.sha256 | sort -k2 > SHA256SUMS
+          echo "--- SHA256SUMS ---"
+          cat SHA256SUMS
+          test -s SHA256SUMS
+
+      - name: Upload SHA256SUMS to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${GITHUB_REF_NAME}" SHA256SUMS --clobber
 
   update-homebrew:
     name: Update Homebrew tap (beta)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,23 @@ jobs:
         shell: bash
         run: gh release upload ${{ needs.setup.outputs.tag }} tokensave-${{ needs.setup.outputs.tag }}-${{ matrix.name }}.${{ matrix.archive }} --clobber
 
+      # Hash the exact bytes just uploaded, on the leg that produced them
+      # (#525). Collected into SHA256SUMS by the checksums job, which
+      # `tokensave upgrade` verifies against before extracting.
+      - name: Record archive SHA256 (unix)
+        if: matrix.archive == 'tar.gz' && needs.setup.outputs.publish == 'true' && needs.setup.outputs.windows_only != 'true'
+        shell: bash
+        run: |
+          ASSET="tokensave-${{ needs.setup.outputs.tag }}-${{ matrix.name }}.${{ matrix.archive }}"
+          sha256sum "$ASSET" > "${ASSET}.sha256"
+
+      - name: Upload checksum artifact (unix)
+        if: matrix.archive == 'tar.gz' && needs.setup.outputs.publish == 'true' && needs.setup.outputs.windows_only != 'true'
+        uses: actions/upload-artifact@v6
+        with:
+          name: checksum-${{ matrix.name }}
+          path: "*.sha256"
+
       # --- Windows: Authenticode signing via SignPath (build half) ---
       # Production signing uses a SignPath Foundation certificate, which requires manual
       # approval in the SignPath UI, so signing is split out into the sign-windows job.
@@ -237,6 +254,73 @@ jobs:
           TAG: ${{ needs.setup.outputs.tag }}
         # This job has no checkout, so gh can't infer the repo from git context.
         run: gh release upload "${TAG}" "tokensave-${TAG}-${{ matrix.name }}.zip" --clobber --repo "$GITHUB_REPOSITORY"
+
+      # Hashed after signing, not before: signing rewrites the .exe, so a hash
+      # taken in the build job would never match what users download (#525).
+      - name: Record archive SHA256 (windows)
+        env:
+          TAG: ${{ needs.setup.outputs.tag }}
+        run: |
+          ASSET="tokensave-${TAG}-${{ matrix.name }}.zip"
+          sha256sum "$ASSET" > "${ASSET}.sha256"
+
+      - name: Upload checksum artifact (windows)
+        uses: actions/upload-artifact@v6
+        with:
+          name: checksum-${{ matrix.name }}
+          path: "*.sha256"
+
+  # Publishes the SHA256SUMS asset `tokensave upgrade` verifies against (#525).
+  #
+  # Merges into whatever SHA256SUMS the release already carries rather than
+  # replacing it. `upgrade` fails closed on a missing hash, so a partial run —
+  # a windows-only re-run, or a re-run of one leg — must not drop the other
+  # platforms' entries and block their upgrades. An asset that was re-uploaded
+  # necessarily ran its leg, so a fresh entry always wins over a stale one.
+  checksums:
+    name: Publish SHA256SUMS
+    if: always() && needs.setup.outputs.publish == 'true' && needs.sign-windows.result == 'success'
+    needs: [setup, build, sign-windows]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download checksum artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: checksum-*
+          path: checksums
+          merge-multiple: true
+
+      - name: Assemble SHA256SUMS
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.setup.outputs.tag }}
+        run: |
+          set -euo pipefail
+          cat checksums/*.sha256 > new.txt
+
+          # Carry forward entries for assets this run did not rebuild.
+          mkdir -p existing
+          if gh release download "$TAG" --pattern SHA256SUMS --dir existing --clobber 2>/dev/null; then
+            awk '{ sub(/^\*/, "", $2); print $2 }' new.txt > fresh-names.txt
+            while read -r line; do
+              [ -n "$line" ] || continue
+              name=$(printf '%s' "$line" | awk '{ sub(/^\*/, "", $2); print $2 }')
+              grep -qxF "$name" fresh-names.txt || printf '%s\n' "$line"
+            done < existing/SHA256SUMS >> new.txt
+          fi
+
+          # Sorted so the asset is byte-stable regardless of leg completion
+          # order, which keeps a re-run from churning the file needlessly.
+          sort -k2 new.txt > SHA256SUMS
+          echo "--- SHA256SUMS ---"
+          cat SHA256SUMS
+          test -s SHA256SUMS
+
+      - name: Upload SHA256SUMS to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.setup.outputs.tag }}
+        run: gh release upload "$TAG" SHA256SUMS --clobber --repo "$GITHUB_REPOSITORY"
 
   update-homebrew:
     name: Update Homebrew tap

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -32,13 +32,32 @@ fn io_err(msg: &str) -> impl Fn(std::io::Error) -> TokenSaveError + '_ {
     }
 }
 
-/// Fetches the `browser_download_url` for a specific asset in a GitHub release.
-fn fetch_asset_url(tag: &str, expected_asset: &str) -> Result<String> {
-    #[derive(serde::Deserialize)]
-    struct Asset {
-        name: String,
-        browser_download_url: String,
-    }
+/// The name of the release asset listing each other asset's SHA256.
+///
+/// Published by both release workflows in `sha256sum` format, one line per
+/// asset.
+const SUMS_ASSET: &str = "SHA256SUMS";
+
+/// One asset attached to a GitHub release.
+#[derive(serde::Deserialize)]
+struct Asset {
+    name: String,
+    browser_download_url: String,
+}
+
+/// A located release asset, together with the SHA256 the release publishes
+/// for it.
+struct VerifiedAsset {
+    url: String,
+    sha256: String,
+}
+
+/// Fetches every asset attached to a release.
+///
+/// One request serves both the binary lookup and the `SHA256SUMS` lookup —
+/// they come from the same release, so asking twice would only add a way for
+/// the two to disagree.
+fn fetch_release_assets(tag: &str) -> Result<Vec<Asset>> {
     #[derive(serde::Deserialize)]
     struct Release {
         assets: Vec<Asset>,
@@ -60,17 +79,103 @@ fn fetch_asset_url(tag: &str, expected_asset: &str) -> Result<String> {
             message: format!("failed to parse release info: {e}"),
         })?;
 
-    release
-        .assets
-        .into_iter()
+    Ok(release.assets)
+}
+
+/// Downloads a small text asset (the sums file) in full.
+fn fetch_text_asset(url: &str) -> Result<String> {
+    let agent = cloud::agent_with_timeout(std::time::Duration::from_secs(30));
+    agent
+        .get(url)
+        .header("User-Agent", "tokensave")
+        .call()
+        .map_err(|e| TokenSaveError::Config {
+            message: format!("failed to download {SUMS_ASSET}: {e}"),
+        })?
+        .body_mut()
+        .read_to_string()
+        .map_err(|e| TokenSaveError::Config {
+            message: format!("failed to read {SUMS_ASSET}: {e}"),
+        })
+}
+
+/// Pulls one asset's hash out of a `sha256sum`-format listing.
+///
+/// Accepts both the text (`hash  name`) and binary (`hash *name`) markers
+/// `sha256sum` emits, and ignores blank lines so a trailing newline is not an
+/// error. Returns `None` when the file is well-formed but does not mention
+/// `asset`, which the caller reports separately from a malformed file.
+fn sha256_for_asset(listing: &str, asset: &str) -> Option<String> {
+    listing.lines().find_map(|line| {
+        let (hash, name) = line.split_once(char::is_whitespace)?;
+        let name = name.trim_start_matches(['*', ' ']).trim();
+        (name == asset && hash.len() == 64 && hash.chars().all(|c| c.is_ascii_hexdigit()))
+            .then(|| hash.to_ascii_lowercase())
+    })
+}
+
+/// Locates the platform's release asset and the SHA256 published for it.
+///
+/// Fails closed (#525). A release whose `SHA256SUMS` is missing, unreadable,
+/// or silent about this asset aborts the upgrade rather than installing an
+/// unverified binary: `upgrade` only ever moves forward to a channel's latest,
+/// so every release a verifying binary can reach is one published after the
+/// sums file started shipping. Treating "no sums" as "skip verification" would
+/// hand anyone who can suppress the file a silent downgrade to no integrity
+/// check at all, which is the property being bought here.
+fn locate_verified_asset(tag: &str, expected_asset: &str) -> Result<VerifiedAsset> {
+    let assets = fetch_release_assets(tag)?;
+
+    let url = assets
+        .iter()
         .find(|a| a.name == expected_asset)
-        .map(|a| a.browser_download_url)
+        .map(|a| a.browser_download_url.clone())
         .ok_or_else(|| TokenSaveError::Config {
             message: format!(
                 "release {tag} exists but asset '{expected_asset}' is not yet available.\n  \
                  CI build may still be in progress — try again in a few minutes.\n  \
                  https://github.com/{GITHUB_REPO}/releases/tag/{tag}",
             ),
+        })?;
+
+    let sums_url = assets
+        .iter()
+        .find(|a| a.name == SUMS_ASSET)
+        .map(|a| a.browser_download_url.clone())
+        .ok_or_else(|| TokenSaveError::Update {
+            message: format!(
+                "release {tag} publishes no {SUMS_ASSET}, so the download cannot be \
+                 verified — refusing to install.\n  \
+                 If CI is still finishing, try again in a few minutes:\n  \
+                 https://github.com/{GITHUB_REPO}/releases/tag/{tag}",
+            ),
+        })?;
+
+    let listing = fetch_text_asset(&sums_url)?;
+    let sha256 =
+        sha256_for_asset(&listing, expected_asset).ok_or_else(|| TokenSaveError::Update {
+            message: format!(
+                "release {tag} publishes {SUMS_ASSET} but it lists no hash for \
+                 '{expected_asset}' — refusing to install.\n  \
+                 https://github.com/{GITHUB_REPO}/releases/tag/{tag}",
+            ),
+        })?;
+
+    Ok(VerifiedAsset { url, sha256 })
+}
+
+/// Hex-encodes the SHA256 of `data`.
+fn sha256_hex(data: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hasher
+        .finalize()
+        .iter()
+        .fold(String::with_capacity(64), |mut acc, byte| {
+            use std::fmt::Write;
+            let _ = write!(acc, "{byte:02x}");
+            acc
         })
 }
 
@@ -124,7 +229,7 @@ fn new_staging_dir() -> Result<tempfile::TempDir> {
 
 /// Downloads the archive from `url` into memory, then extracts `bin_name`
 /// into a freshly created private directory. Returns the staged binary.
-fn download_and_extract(url: &str, bin_name: &str) -> Result<StagedBinary> {
+fn download_and_extract(url: &str, bin_name: &str, expected_sha256: &str) -> Result<StagedBinary> {
     let tmp_dir = new_staging_dir()?;
     let tmp_path = tmp_dir.path().join(format!(
         "tokensave{}",
@@ -155,6 +260,26 @@ fn download_and_extract(url: &str, bin_name: &str) -> Result<StagedBinary> {
     };
 
     eprintln!(" ({:.1} MiB)", raw.len() as f64 / 1_048_576.0);
+
+    // Verified before extraction, not after (#525): extraction writes the
+    // archive's contents to disk, so a mismatched archive must never reach it.
+    eprint!("  Verifying...");
+    let actual = sha256_hex(&raw);
+    if actual != expected_sha256 {
+        eprintln!(" \x1b[31mFAILED\x1b[0m");
+        return Err(TokenSaveError::Update {
+            message: format!(
+                "downloaded archive does not match the SHA256 published for it — \
+                 refusing to install.\n  \
+                 expected: {expected_sha256}\n  \
+                 actual:   {actual}\n  \
+                 This means the download was corrupted or tampered with. \
+                 Nothing has been installed."
+            ),
+        });
+    }
+    eprintln!(" OK");
+
     eprint!("  Extracting...");
 
     #[cfg(not(windows))]
@@ -525,11 +650,14 @@ fn replace_for_scoop(new_exe: &Path, _new_version: &str) -> Result<()> {
 /// Verifies the release asset exists on GitHub and returns the download URL.
 /// Call this early so we fail fast when CI hasn't finished building the
 /// release yet.
-fn preflight_asset_check(version: &str, is_beta: bool) -> Result<String> {
+fn preflight_asset_check(version: &str, is_beta: bool) -> Result<VerifiedAsset> {
     let tag = release_tag(version);
     let expected = asset_name(version, is_beta);
     eprintln!("  Asset: {expected}");
-    fetch_asset_url(&tag, &expected)
+    // Resolving the hash here rather than mid-download keeps the fail-fast
+    // property the asset check already had: a release missing its sums fails
+    // before the archive is fetched, not after ~150 MiB of it.
+    locate_verified_asset(&tag, &expected)
 }
 
 /// Record the *currently running* binary's version in user config just before
@@ -552,14 +680,14 @@ fn record_previous_version() {
     }
 }
 
-fn perform_upgrade(version: &str, asset_url: &str, method: &InstallMethod) -> Result<()> {
+fn perform_upgrade(version: &str, asset: &VerifiedAsset, method: &InstallMethod) -> Result<()> {
     let bin_name = if cfg!(windows) {
         "tokensave.exe"
     } else {
         "tokensave"
     };
 
-    let staged = download_and_extract(asset_url, bin_name)?;
+    let staged = download_and_extract(&asset.url, bin_name, &asset.sha256)?;
 
     let label = match method {
         InstallMethod::Brew => " (Homebrew Cellar)",
@@ -906,9 +1034,9 @@ pub fn run_upgrade(kill: bool) -> Result<String> {
 
     handle_running_processes(kill)?;
 
-    let asset_url = preflight_asset_check(latest, is_beta)?;
+    let asset = preflight_asset_check(latest, is_beta)?;
 
-    perform_upgrade(latest, &asset_url, &method)?;
+    perform_upgrade(latest, &asset, &method)?;
     record_previous_version();
     eprintln!("\x1b[32m✔\x1b[0m Successfully upgraded to v{latest}!");
     Ok(latest.to_string())
@@ -957,9 +1085,9 @@ pub fn switch_channel(target_channel: &str) -> Result<String> {
 
     eprintln!("  Target: v{latest}");
 
-    let asset_url = preflight_asset_check(&latest, target_is_beta)?;
+    let asset = preflight_asset_check(&latest, target_is_beta)?;
 
-    perform_upgrade(&latest, &asset_url, &method)?;
+    perform_upgrade(&latest, &asset, &method)?;
     record_previous_version();
     eprintln!("\x1b[32m✔\x1b[0m Switched to {target_channel} channel: v{latest}");
     Ok(latest)
@@ -1046,6 +1174,90 @@ mod tests {
         assert!(
             staged.starts_with(dir.path()),
             "the staged binary must be contained by the private directory"
+        );
+    }
+
+    // ── SHA256 verification (#525) ───────────────────────────────────────
+
+    #[test]
+    fn sha256_hex_matches_a_known_vector() {
+        // The empty-input digest, so this pins the encoding rather than
+        // restating whatever the implementation happens to produce.
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn a_sums_listing_yields_the_hash_for_the_named_asset() {
+        let listing = "\
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  tokensave-v1.2.3-x86_64-linux.tar.gz
+ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad  tokensave-v1.2.3-aarch64-macos.tar.gz
+";
+        assert_eq!(
+            sha256_for_asset(listing, "tokensave-v1.2.3-aarch64-macos.tar.gz").as_deref(),
+            Some("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+        );
+    }
+
+    #[test]
+    fn a_sums_listing_accepts_the_binary_mode_marker() {
+        // `sha256sum -b` and the Windows leg emit `hash *name`.
+        let listing =
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 *tokensave-v1.2.3-x86_64-windows.zip\n";
+        assert_eq!(
+            sha256_for_asset(listing, "tokensave-v1.2.3-x86_64-windows.zip").as_deref(),
+            Some("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+        );
+    }
+
+    #[test]
+    fn an_asset_absent_from_the_listing_has_no_hash() {
+        // The caller turns this into a refusal, not a skipped check — a
+        // release that does not name our asset must not install (#525).
+        let listing =
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  some-other-asset.tar.gz\n";
+        assert!(sha256_for_asset(listing, "tokensave-v1.2.3-x86_64-linux.tar.gz").is_none());
+    }
+
+    #[test]
+    fn a_malformed_or_truncated_hash_is_not_accepted() {
+        // A short, over-long, or non-hex field must not be treated as a hash:
+        // it would compare unequal to every real digest and turn a verifiable
+        // release into an unexplained mismatch.
+        for bad in [
+            "deadbeef  tokensave-v1.2.3-x86_64-linux.tar.gz",
+            "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz  tokensave-v1.2.3-x86_64-linux.tar.gz",
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855aa  tokensave-v1.2.3-x86_64-linux.tar.gz",
+        ] {
+            assert!(
+                sha256_for_asset(bad, "tokensave-v1.2.3-x86_64-linux.tar.gz").is_none(),
+                "{bad} should not parse as a hash"
+            );
+        }
+    }
+
+    #[test]
+    fn an_empty_or_blank_listing_has_no_hash() {
+        for listing in ["", "\n", "   \n\n"] {
+            assert!(sha256_for_asset(listing, "tokensave-v1.2.3-x86_64-linux.tar.gz").is_none());
+        }
+    }
+
+    #[test]
+    fn a_hash_is_compared_case_insensitively() {
+        // Some tools emit uppercase hex; normalising on parse keeps that from
+        // reading as tampering.
+        let listing =
+            "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855  tokensave-v1.2.3-x86_64-linux.tar.gz\n";
+        assert_eq!(
+            sha256_for_asset(listing, "tokensave-v1.2.3-x86_64-linux.tar.gz").as_deref(),
+            Some(sha256_hex(b"").as_str())
         );
     }
 


### PR DESCRIPTION
Closes #525 (the checksum half; the predictable-temp-path half landed in `97f32fe`).

## What

Release workflows publish a `SHA256SUMS` asset for stable and beta. `upgrade` verifies the archive against it **before extraction** — before, because extraction writes the archive's contents to disk, so a mismatched archive must never reach it.

## Fails closed, deliberately

A release with no `SHA256SUMS`, or whose sums file does not name this platform's asset, aborts the upgrade rather than installing unverified. There is no legacy-tag fallback, and that is a decision rather than an oversight:

`upgrade` only ever moves forward to a channel's latest, so every release a verifying binary can reach is one published after this lands. The "keep a fallback for older tags" branch the issue suggests would therefore never execute. Meanwhile, treating a missing sums file as "skip verification" would hand anyone able to suppress that file a silent downgrade to exactly today's behaviour — which is the property being bought.

The trade-off accepted: if CI ever fails to publish sums for a release, upgrades block until it is fixed. That is the intended direction for the failure to point.

## Notes on the implementation

- The hash resolves during the existing preflight, so a release missing its sums fails **before** the archive is fetched rather than after ~150 MiB of it. Both lookups share one API call — asking twice only adds a way for them to disagree.
- Hashes are recorded on the leg that produced the bytes, not by re-downloading ~900 MiB of assets.
- The Windows hash is taken in `sign-windows` **after** signing. Signing rewrites the `.exe`, so a hash taken in the build job would never match what users download.
- The stable job **merges** into any `SHA256SUMS` already on the release rather than replacing it. Under fail-closed, a windows-only re-run that truncated the file would block upgrades for every other platform. An asset that was re-uploaded necessarily ran its leg, so a fresh entry always wins over a stale one.

## Known gap, stated rather than papered over

The first release carrying `SHA256SUMS` cannot be verified by the binary upgrading *into* it, since the installed version predates this code. Verification starts biting one release later. Nothing here can change that.

## Scope

Checksums only. Signing (sigstore/minisign) is a further step and is not attempted here — checksums served over TLS from the same origin as the artifact do not protect against a compromised release pipeline, which is what signing would address.

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --features test-transport` — 0 warnings
- 940 lib tests, 172 integration targets, 0 failures
- `actionlint` on both workflows — no new findings (the 6 reported are pre-existing: `env` context in beta `if:` guards, and two `SC2034`/`SC2006` in existing steps)
- The merge logic was exercised locally against a simulated windows-only re-run: the fresh Windows hash replaced the stale entry, both untouched platforms carried forward

Tests cover the digest encoding against known vectors (empty input and `abc`), both `sha256sum` output markers (`hash  name` and `hash *name`), uppercase hex, and the malformed/absent/blank cases that must not parse as a hash — a short or non-hex field would otherwise compare unequal to every real digest and turn a verifiable release into an unexplained mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)