### PR TITLE
feat(audit): add `tokensave audit-edges`, a layout-independent phantom-edge metric (#536)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -277,6 +277,22 @@ pub enum Commands {
         #[arg(long, value_name = "PATH")]
         path: Option<String>,
     },
+    /// Audit bare-name resolution quality over the built index
+    ///
+    /// Counts cross-file edges resolved through the bare-name path whose
+    /// target is the sole symbol of that name — the population the
+    /// reachability gate governs. Read it comparatively: index a tree at two
+    /// commits and diff the counts. Unlike a production-to-`tests/` count it
+    /// also sees phantoms landing inside production, and needs no
+    /// test/production classification, so it is not sensitive to layout.
+    AuditEdges {
+        /// How many of the most-collided targets to list
+        #[arg(long, default_value_t = 10)]
+        top: usize,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
     /// Check tokensave installation, configuration, and agent integration
     Doctor {
         /// Check only this agent (default: all agents)

--- a/src/edge_audit.rs
+++ b/src/edge_audit.rs
@@ -1,0 +1,267 @@
+//! Audit of bare-name resolution quality over a built index (#536).
+//!
+//! The impossible-edge metric used to evaluate #533 counted edges crossing
+//! from production into `tests/`. That is a proxy, and a lossy one: measured
+//! against its own parent, #533 removed 1,216 edges on a 515-file Python
+//! project while the metric saw 731. The other 485 were the identical defect
+//! landing production → production, where a directory-crossing test cannot see
+//! them — which read as 60% precision when the evidence said close to 100%.
+//!
+//! This counts what the gate actually governs instead: cross-file edges
+//! resolved through the bare-name path, in a language where a bare name is not
+//! by itself evidence of a binding, whose target is the sole symbol of that
+//! name in the index. That population needs no test/production classification,
+//! so it is not sensitive to repository layout.
+//!
+//! It is a **population count, not a phantom count.** Every edge reported here
+//! passed `is_plausibly_reachable` at resolution time — the ones that failed it
+//! are absent from the index and cannot be counted from the index. The number
+//! is read comparatively: index a tree at two commits and diff the counts, the
+//! way #533 was measured. A resolution change that removes phantoms shows up
+//! as a drop here whether the phantom crossed into `tests/` or not.
+
+use crate::db::Database;
+use crate::errors::{Result, TokenSaveError};
+use std::collections::{HashMap, HashSet};
+
+/// Languages where a bare name alone is not evidence of a binding, mirroring
+/// `resolution::resolver::bare_name_needs_evidence`. Ruby is deliberately
+/// absent there and so is absent here; the two lists must not drift.
+fn is_gated_path(path: &str) -> bool {
+    let ext = path.rsplit('.').next().unwrap_or_default();
+    matches!(
+        ext,
+        "py" | "pyi" | "js" | "jsx" | "mjs" | "cjs" | "ts" | "tsx"
+    )
+}
+
+fn dir_of(path: &str) -> &str {
+    path.rfind('/').map_or("", |i| &path[..i])
+}
+
+/// Whether `imports` for a file carries evidence of `name`.
+///
+/// Mirrors the resolver's reading: an entry matches when it equals the name
+/// outright or ends with it as a dotted segment, so `import pkg.mod.analyzer`
+/// counts as importing `analyzer`.
+fn imports_name(imports: &HashSet<String>, name: &str) -> bool {
+    imports
+        .iter()
+        .any(|entry| entry == name || entry.rsplit('.').next() == Some(name))
+}
+
+/// One target that many bare-name references collapsed onto.
+#[derive(Debug, Clone)]
+pub struct HotTarget {
+    pub name: String,
+    pub file_path: String,
+    pub start_line: i64,
+    pub kind: String,
+    /// How many distinct source files hold an unreachable edge to this target.
+    pub source_files: i64,
+    pub edges: i64,
+}
+
+/// The result of an edge audit over one index.
+#[derive(Debug, Clone)]
+pub struct EdgeAudit {
+    pub total_edges: i64,
+    /// Edges whose source file is in a gated language.
+    pub gated_edges: i64,
+    /// ...of which cross a file boundary.
+    pub cross_file: i64,
+    /// ...of which also target the sole symbol of that name in the index.
+    pub sole_candidate_cross_file: i64,
+    /// ...of which the source file has no evidence it can reach. This is the
+    /// figure to diff between two commits.
+    pub unreachable: i64,
+    /// The targets absorbing the most unreachable edges, largest first.
+    pub hot_targets: Vec<HotTarget>,
+}
+
+/// One edge, flattened with the node facts the predicate needs.
+struct EdgeRow {
+    src_file: String,
+    dst_id: String,
+    dst_name: String,
+    dst_file: String,
+    dst_kind: String,
+    dst_line: i64,
+    dst_parent: Option<String>,
+}
+
+async fn query_rows(db: &Database, sql: &str) -> Result<libsql::Rows> {
+    db.conn()
+        .query(sql, ())
+        .await
+        .map_err(|e| TokenSaveError::Database {
+            message: format!("edge audit query failed: {e}"),
+            operation: "edge_audit".to_string(),
+        })
+}
+
+/// Runs the audit over `db`.
+///
+/// `limit` caps how many hot targets are listed.
+pub async fn audit(db: &Database, limit: usize) -> Result<EdgeAudit> {
+    // Import evidence per file. Imports are graph nodes of kind `use`, which
+    // is what lets the gate's predicate be evaluated after the fact rather
+    // than only during resolution.
+    let mut imports: HashMap<String, HashSet<String>> = HashMap::new();
+    let mut rows = query_rows(db, "SELECT file_path, name FROM nodes WHERE kind = 'use'").await?;
+    while let Some(row) = rows.next().await.map_err(|e| TokenSaveError::Database {
+        message: format!("edge audit read failed: {e}"),
+        operation: "edge_audit".to_string(),
+    })? {
+        let file: String = row.get(0).unwrap_or_default();
+        let name: String = row.get(1).unwrap_or_default();
+        imports.entry(file).or_default().insert(name);
+    }
+
+    // How many symbols share each name, so "sole candidate" is a lookup.
+    let mut name_counts: HashMap<String, i64> = HashMap::new();
+    let mut rows = query_rows(
+        db,
+        "SELECT name, COUNT(*) FROM nodes WHERE kind <> 'file' AND kind <> 'use' GROUP BY name",
+    )
+    .await?;
+    while let Some(row) = rows.next().await.map_err(|e| TokenSaveError::Database {
+        message: format!("edge audit read failed: {e}"),
+        operation: "edge_audit".to_string(),
+    })? {
+        name_counts.insert(
+            row.get(0).unwrap_or_default(),
+            row.get(1).unwrap_or_default(),
+        );
+    }
+
+    // Parent names, for the "the class that owns the method is the evidence"
+    // arm of the resolver's predicate.
+    let mut node_name: HashMap<String, String> = HashMap::new();
+    let mut rows = query_rows(db, "SELECT id, name FROM nodes").await?;
+    while let Some(row) = rows.next().await.map_err(|e| TokenSaveError::Database {
+        message: format!("edge audit read failed: {e}"),
+        operation: "edge_audit".to_string(),
+    })? {
+        node_name.insert(
+            row.get(0).unwrap_or_default(),
+            row.get(1).unwrap_or_default(),
+        );
+    }
+
+    let mut total_edges = 0i64;
+    let mut gated_edges = 0i64;
+    let mut cross_file = 0i64;
+    let mut sole_candidate_cross_file = 0i64;
+    let mut unreachable = 0i64;
+    let mut per_target: HashMap<String, (EdgeRow, i64, HashSet<String>)> = HashMap::new();
+
+    let mut rows = query_rows(
+        db,
+        "SELECT s.file_path, n.id, n.name, n.file_path, n.kind, n.start_line, n.parent_id \
+         FROM edges e \
+         JOIN nodes n ON n.id = e.target \
+         JOIN nodes s ON s.id = e.source",
+    )
+    .await?;
+
+    while let Some(row) = rows.next().await.map_err(|e| TokenSaveError::Database {
+        message: format!("edge audit read failed: {e}"),
+        operation: "edge_audit".to_string(),
+    })? {
+        total_edges += 1;
+        let r = EdgeRow {
+            src_file: row.get(0).unwrap_or_default(),
+            dst_id: row.get(1).unwrap_or_default(),
+            dst_name: row.get(2).unwrap_or_default(),
+            dst_file: row.get(3).unwrap_or_default(),
+            dst_kind: row.get(4).unwrap_or_default(),
+            dst_line: row.get(5).unwrap_or_default(),
+            dst_parent: row.get::<Option<String>>(6).unwrap_or_default(),
+        };
+
+        if !is_gated_path(&r.src_file) {
+            continue;
+        }
+        gated_edges += 1;
+
+        if r.src_file == r.dst_file {
+            continue;
+        }
+        cross_file += 1;
+
+        if name_counts.get(&r.dst_name).copied().unwrap_or(0) != 1 {
+            continue;
+        }
+        sole_candidate_cross_file += 1;
+
+        // The resolver's evidence model, evaluated after the fact: same
+        // directory, the name imported, or the owning class imported.
+        if dir_of(&r.src_file) == dir_of(&r.dst_file) {
+            continue;
+        }
+        let file_imports = imports.get(&r.src_file);
+        let reachable = file_imports.is_some_and(|imports| {
+            imports_name(imports, &r.dst_name)
+                || r.dst_parent
+                    .as_deref()
+                    .and_then(|id| node_name.get(id))
+                    .is_some_and(|parent| imports_name(imports, parent))
+        });
+        if reachable {
+            continue;
+        }
+
+        unreachable += 1;
+        let entry = per_target
+            .entry(r.dst_id.clone())
+            .or_insert_with(|| (r, 0, HashSet::new()));
+        entry.1 += 1;
+        entry.2.insert(entry.0.src_file.clone());
+    }
+
+    // `src_file` on the stored row is whichever edge landed first, so the
+    // distinct-source count is tracked separately rather than read off it.
+    let mut hot: Vec<(EdgeRow, i64, HashSet<String>)> = per_target.into_values().collect();
+    hot.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.dst_name.cmp(&b.0.dst_name)));
+    let hot_targets = hot
+        .into_iter()
+        .take(limit)
+        .map(|(r, edges, files)| HotTarget {
+            name: r.dst_name,
+            file_path: r.dst_file,
+            start_line: r.dst_line,
+            kind: r.dst_kind,
+            source_files: files.len() as i64,
+            edges,
+        })
+        .collect();
+
+    Ok(EdgeAudit {
+        total_edges,
+        gated_edges,
+        cross_file,
+        sole_candidate_cross_file,
+        unreachable,
+        hot_targets,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gating_follows_the_resolver_language_list() {
+        for path in [
+            "a/b.py", "a/b.pyi", "x.js", "x.jsx", "x.mjs", "x.ts", "x.tsx",
+        ] {
+            assert!(is_gated_path(path), "{path} should be gated");
+        }
+        // Rust and Go resolve bare names through a module system the gate
+        // cannot see, and Ruby is deliberately excluded in the resolver.
+        for path in ["src/main.rs", "m.go", "a.rb", "x.java", "no_extension"] {
+            assert!(!is_gated_path(path), "{path} must not be gated");
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub mod diagnostics;
 pub mod display;
 pub mod docs;
 pub mod doctor;
+pub mod edge_audit;
 pub mod errors;
 pub mod extraction;
 pub mod extraction_worker;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1332,6 +1332,81 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
                 }
             }
         }
+        Commands::AuditEdges { top, json } => {
+            let project_path = tokensave::config::resolve_path_with_discovery(None);
+            if !TokenSave::is_initialized(&project_path) {
+                return Err(tokensave::errors::TokenSaveError::Config {
+                    message: format!(
+                        "no TokenSave index at '{}' — run `tokensave init` first",
+                        project_path.display()
+                    ),
+                });
+            }
+            let cg = TokenSave::open(&project_path).await?;
+            let report = tokensave::edge_audit::audit(cg.db(), top).await?;
+
+            if json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "total_edges": report.total_edges,
+                        "gated_edges": report.gated_edges,
+                        "cross_file": report.cross_file,
+                        "sole_candidate_cross_file": report.sole_candidate_cross_file,
+                        "unreachable": report.unreachable,
+                        "hot_targets": report.hot_targets.iter().map(|t| serde_json::json!({
+                            "name": t.name,
+                            "file": t.file_path,
+                            "line": t.start_line,
+                            "kind": t.kind,
+                            "source_files": t.source_files,
+                            "edges": t.edges,
+                        })).collect::<Vec<_>>(),
+                    })
+                );
+            } else {
+                println!("Edge audit — {}", project_path.display());
+                println!(
+                    "  total edges                       {:>8}",
+                    report.total_edges
+                );
+                println!(
+                    "  in gated languages (py/js/ts)     {:>8}",
+                    report.gated_edges
+                );
+                println!(
+                    "    cross-file                      {:>8}",
+                    report.cross_file
+                );
+                println!(
+                    "    sole-candidate                  {:>8}",
+                    report.sole_candidate_cross_file
+                );
+                println!(
+                    "      without reachability evidence {:>8}   <- diff this between commits",
+                    report.unreachable
+                );
+
+                if report.hot_targets.is_empty() {
+                    println!("\nNo unreachable sole-candidate cross-file targets.");
+                } else {
+                    println!("\nMost-collided targets:");
+                    for t in &report.hot_targets {
+                        println!(
+                            "  {:>6} edges from {:>4} files  {}:{}  {} ({})",
+                            t.edges, t.source_files, t.file_path, t.start_line, t.name, t.kind
+                        );
+                    }
+                }
+                println!(
+                    "\nAn edge counted here is one the index asserts but the source file \
+                     carries no\nevidence it can reach — same directory, the name imported, \
+                     or the owning class\nimported. Unlike a production-to-tests/ count it \
+                     also sees phantoms landing inside\nproduction, and needs no \
+                     test/production classification."
+                );
+            }
+        }
         Commands::Doctor { agent } => {
             tokensave::doctor::run_doctor(agent.as_deref()).await;
         }
@@ -1651,6 +1726,7 @@ fn should_skip_agent_install_maintenance(command: &Commands) -> bool {
             | Commands::Reinstall { .. }
             | Commands::Uninstall { .. }
             | Commands::Doctor { .. }
+            | Commands::AuditEdges { .. }
             // `Serve` is the hot path used by MCP clients (Claude Code,
             // Codex, etc.). Clients impose a 30 s `initialize` timeout, so
             // every pre-serve startup task — `try_flush` network round-trip,

--- a/tests/edge_audit_test.rs
+++ b/tests/edge_audit_test.rs
@@ -1,0 +1,123 @@
+//! The edge audit must see phantoms landing inside production (#536).
+//!
+//! The impossible-edge metric #533 was evaluated with counted edges crossing
+//! into `tests/`. Measured against its own parent, #533 removed 1,216 edges on
+//! a 515-file Python project while that metric saw 731 — the other 485 were
+//! the same defect landing production → production, invisible to a
+//! directory-crossing count. These tests pin that the audit sees both, and
+//! that it does not mistake a legitimately reachable edge for a phantom.
+
+use tempfile::tempdir;
+use tokensave::edge_audit;
+use tokensave::tokensave::TokenSave;
+
+/// The measured shape: a closure `p` nested in a method, the sole symbol of
+/// that name, plus an ordinary local `p` in a different production package
+/// importing nothing from it. Neither end is in a test tree.
+async fn fixture() -> (tempfile::TempDir, TokenSave) {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("ui")).unwrap();
+    std::fs::create_dir_all(root.join("util")).unwrap();
+
+    std::fs::write(
+        root.join("ui/panel.py"),
+        "import tkinter as tk\n\n\nclass Panel:\n    def writers(self):\n        t = self._txt\n\n        def p(s):\n            t.insert(tk.END, s)\n\n        return p\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("util/paths.py"),
+        "import os\n\n\ndef cache_dir(root):\n    p = os.path.join(root, \".cache\")\n    return p\n",
+    )
+    .unwrap();
+    // The recall control: an explicitly imported cross-package name.
+    std::fs::write(
+        root.join("ui/widgets.py"),
+        "def render_banner():\n    return \"banner\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("util/report.py"),
+        "from ui.widgets import render_banner\n\n\ndef build():\n    return render_banner()\n",
+    )
+    .unwrap();
+
+    let cg = TokenSave::init(root).await.unwrap();
+    cg.sync().await.unwrap();
+    (tmp, cg)
+}
+
+#[tokio::test]
+async fn a_correctly_resolved_index_reports_no_unreachable_edges() {
+    let (_tmp, cg) = fixture().await;
+    let report = edge_audit::audit(cg.db(), 10).await.unwrap();
+
+    assert_eq!(
+        report.unreachable, 0,
+        "current resolution should leave no unreachable sole-candidate edges"
+    );
+    assert!(
+        report.hot_targets.is_empty(),
+        "nothing to report when there are no unreachable edges"
+    );
+    // The imported cross-package edge is still counted as sole-candidate and
+    // cross-file — it is excluded by the reachability arm, not by failing to
+    // be seen. Without this the zero above could be vacuous.
+    assert!(
+        report.sole_candidate_cross_file > 0,
+        "the audit must still be looking at cross-file sole-candidate edges"
+    );
+}
+
+#[tokio::test]
+async fn a_phantom_edge_inside_production_is_counted() {
+    let (_tmp, cg) = fixture().await;
+
+    // Reintroduce the edge the gate now refuses, as a pre-#533 index would
+    // carry it: `cache_dir` in util/ binding to the closure `p` in ui/. Both
+    // ends are production, so a production-to-tests/ metric cannot see it.
+    let source: String = {
+        let mut rows = cg
+            .db()
+            .conn()
+            .query(
+                "SELECT id FROM nodes WHERE name = 'cache_dir' AND kind = 'function'",
+                (),
+            )
+            .await
+            .unwrap();
+        rows.next().await.unwrap().unwrap().get(0).unwrap()
+    };
+    let target: String = {
+        let mut rows = cg
+            .db()
+            .conn()
+            .query(
+                "SELECT id FROM nodes WHERE name = 'p' AND file_path = 'ui/panel.py'",
+                (),
+            )
+            .await
+            .unwrap();
+        rows.next().await.unwrap().unwrap().get(0).unwrap()
+    };
+    cg.db()
+        .conn()
+        .execute(
+            "INSERT INTO edges (source, target, kind, line) VALUES (?1, ?2, 'uses', 5)",
+            libsql::params![source.as_str(), target.as_str()],
+        )
+        .await
+        .unwrap();
+
+    let report = edge_audit::audit(cg.db(), 10).await.unwrap();
+
+    assert_eq!(
+        report.unreachable, 1,
+        "the production → production phantom must be counted"
+    );
+    let hot = &report.hot_targets[0];
+    assert_eq!(hot.name, "p");
+    assert_eq!(hot.file_path, "ui/panel.py");
+    assert_eq!(hot.edges, 1);
+    assert_eq!(hot.source_files, 1);
+}


### PR DESCRIPTION
Closes #536.

## The problem being fixed

The impossible-edge count used to evaluate #533 measured edges crossing from production into `tests/`. Measured against its own parent, #533 removed **1,216** edges on a 515-file Python project while that metric saw **731**. The other 485 were the identical defect landing production → production, invisible to a directory-crossing count — so #533 read as 60% precision when the evidence said close to 100%.

## What this adds

`tokensave audit-edges` counts what the reachability gate actually governs: cross-file edges in a gated language whose target is the sole symbol of that name, and for which the source file carries no evidence it can reach the target. No test/production classification, so it is not sensitive to layout.

```
Edge audit — /path/to/project
  total edges                              5
  in gated languages (py/js/ts)            5
    cross-file                             4
    sole-candidate                         4
      without reachability evidence        2   <- diff this between commits

Most-collided targets:
       2 edges from    1 files  ui/panel.py:7  p (function)
```

`--json` for machine consumption, `--top N` to widen the target list.

## The predicate is evaluated, not proxied

Imports turn out to be graph nodes of kind `use`, which makes the resolver's evidence model — same directory, the name imported, the owning class imported — reconstructible from a built index. So this evaluates the actual predicate after the fact rather than approximating it.

**One finding worth flagging separately:** `edges.resolved_by` is not usable for this, and not for anything else either. The resolver populates that field on every edge it creates (`resolved_by: "simple-name-match"`, `"exact-match"`, …) but **nothing persists it** — there are no references to it under `src/db/`. The column present in older databases is a leftover from a previous schema, not live data. Resolution provenance is computed on every index and discarded. That may be worth its own issue; persisting it would make several questions cheap that are currently expensive.

## Validated end to end, not only by unit test

Indexing the measured shape with the **pre-#533 binary** (`97f32fe`) and auditing that index with this build:

```
without reachability evidence        2
Most-collided targets:
     2 edges from    1 files  ui/panel.py:7  p (function)
```

The same tree indexed by current master reports **0**. That is the `exe`/`p` shape from #536 with both ends in production, detected and then shown to disappear across the fix — the comparative reading the issue asks for.

The recall control (an explicitly imported cross-package name) is counted as sole-candidate and cross-file throughout and excluded only by the reachability arm, so the zero is not vacuous. The tests assert that explicitly.

## Scope

Report-only, per the issue's framing: no CI gate, no threshold, no fixture to maintain. The phantom-detection test reintroduces the edge the gate now refuses, so detection is pinned without depending on an old binary being available at test time.

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --features test-transport` — 0 warnings
- 941 lib tests, 173 integration targets, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)