### PR TITLE
feat(config): explain environment override precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [maintenance-based versioning](TOKENSAVE-VERSIONING.md), not SemVer.
 
+## [Unreleased]
+
+### Changed
+- **Generated project configuration now explains environment-variable precedence.** A JSON-safe `_comment` field tells users that matching `TOKENSAVE_*` variables override values in `.tokensave/config.json`.
+
 ## [7.12.1] - 2026-09-12
 
 ### Fixed

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -717,15 +717,6 @@ being asked would be a bad surprise. Nothing new is detected when you enable
 it — the same conditions were already detected, this only changes whether they
 warn or refuse.
 
-### Configuration and environment overrides
-
-`.tokensave/config.json` is generated as ordinary JSON. It includes an
-`_comment` metadata field explaining that `TOKENSAVE_*` environment variables
-override matching config values when set. This is especially relevant for
-`TOKENSAVE_AUTO_TRACK`, `TOKENSAVE_REPORT_SAVINGS`, and
-`TOKENSAVE_UPDATE_CHECK`.
-
-
 ### CLI-Only Workflows
 
 If you don't keep an agent attached, no MCP server is running to refresh the
@@ -1205,6 +1196,14 @@ tokensave sync --force # to rebuild an index you suspect is wrong
 ## Configuration Files
 
 Tokensave stores data in two places.
+
+### Configuration and environment overrides
+
+`.tokensave/config.json` is generated as ordinary JSON. It includes an
+`_comment` metadata field explaining that `TOKENSAVE_*` environment variables
+override matching config values when set. This is especially relevant for
+`TOKENSAVE_AUTO_TRACK`, `TOKENSAVE_REPORT_SAVINGS`, and
+`TOKENSAVE_UPDATE_CHECK`.
 
 ### Per-project: `.tokensave/`
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -717,6 +717,14 @@ being asked would be a bad surprise. Nothing new is detected when you enable
 it — the same conditions were already detected, this only changes whether they
 warn or refuse.
 
+### Configuration and environment overrides
+
+`.tokensave/config.json` is generated as ordinary JSON. It includes an
+`_comment` metadata field explaining that `TOKENSAVE_*` environment variables
+override matching config values when set. This is especially relevant for
+`TOKENSAVE_AUTO_TRACK`, `TOKENSAVE_REPORT_SAVINGS`, and
+`TOKENSAVE_UPDATE_CHECK`.
+
 
 ### CLI-Only Workflows
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -298,7 +298,19 @@ pub fn save_config(project_root: &Path, config: &TokenSaveConfig) -> Result<()> 
     let config_path = get_config_path(project_root);
     let tmp_path = config_path.with_extension("tmp");
 
-    let json = serde_json::to_string_pretty(config).map_err(|e| TokenSaveError::Config {
+    let mut value = serde_json::to_value(config).map_err(|e| TokenSaveError::Config {
+        message: format!("failed to serialize config: {e}"),
+    })?;
+    if let Some(object) = value.as_object_mut() {
+        object.insert(
+            "_comment".to_string(),
+            serde_json::Value::String(
+                "TOKENSAVE_* environment variables override matching config values when set."
+                    .to_string(),
+            ),
+        );
+    }
+    let json = serde_json::to_string_pretty(&value).map_err(|e| TokenSaveError::Config {
         message: format!("failed to serialize config: {e}"),
     })?;
 

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -19,6 +19,17 @@ fn test_save_and_load_config() {
 }
 
 #[test]
+fn test_generated_config_explains_environment_overrides() {
+    let dir = TempDir::new().unwrap();
+    save_config(dir.path(), &TokenSaveConfig::default()).unwrap();
+
+    let text = std::fs::read_to_string(dir.path().join(".tokensave/config.json")).unwrap();
+    assert!(text.contains("\"_comment\""));
+    assert!(text.contains("TOKENSAVE_* environment variables override"));
+    assert!(serde_json::from_str::<TokenSaveConfig>(&text).is_ok());
+}
+
+#[test]
 fn test_is_excluded() {
     let config = TokenSaveConfig::default();
     assert!(!is_excluded("src/main.rs", &config));


### PR DESCRIPTION
## Summary

- Resolves #546.
- Explains environment-variable precedence directly in generated `.tokensave/config.json`.
- Documents the same rule in the user guide without pretending JSON supports comments.

## Motivation

`TOKENSAVE_AUTO_TRACK=1` can make automatic branch tracking effective even when a project file says `"auto_track": false`. The behavior is correct and already tested, but the generated file does not tell the operator why the visible value is not authoritative.

## Changes

- `src/config.rs`: add a `_comment` metadata field when serializing generated config; unknown metadata remains ignored when loading.
- `tests/config_test.rs`: verify the note is emitted and the annotated JSON still deserializes.
- `docs/USER-GUIDE.md`: document the precedence and name the main override variables.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --test config_test` (42 passed)

## Checklist

- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [x] No secrets, credentials, or `.env` files included
- [x] Breaking changes documented (not applicable)
- [x] Existing config files remain readable
- [x] No new dependency