### PR TITLE
fix(db): escape the path filter in the remaining LIKE queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [maintenance-based versioning](TOKENSAVE-VERSIONING.md), not SemVer.
 
+## [Unreleased]
+
+### Fixed
+- **A path filter no longer treats `_` and `%` as wildcards in the ten queries #524 did not reach.** #524 fixed three queries that interpolated the caller's path into `LIKE '{prefix}%'`. Ten more bound it as a parameter, `format!("{prefix}%")`, which is why an apostrophe never failed there, but binding does not change what `_` and `%` mean inside `LIKE`: `--path src/my_mod` also returned `src/myXmod`, and `--path 'src/%'` returned every directory. The tools that reach them are `rank`, `largest`, `distribution`, `recursion`, `complexity`, `doc_coverage`, `annotations` (its `file` filter, in both modes), `port_status` and `port_order`; the tenth query, `get_call_edges`, has no caller outside the tests. It needed no path from the caller either: with no `path` argument these tools scope to the directory the server was launched from, so a server started inside `svc/user_api` also answered with `svc/userXapi`. All ten now share `push_path_prefix_filter` with the three #524 fixed, so they also match the directory itself plus everything under it rather than any path merely starting with those characters: `--path src/my` no longer matches `src/my_mod`, and a single file is named in full. The tool descriptions that said "prefix" now say file or directory.
+
 ## [7.12.1] - 2026-09-12
 
 ### Fixed

--- a/src/db/queries/edges.rs
+++ b/src/db/queries/edges.rs
@@ -459,8 +459,8 @@ impl Database {
 
     /// Histogram of annotation / attribute / decorator usages across the
     /// project. Each row is `(annotation_name, count)` sorted descending by
-    /// count. Optional `path_prefix` restricts to nodes whose `file_path`
-    /// starts with that string.
+    /// count. Optional `path_prefix` restricts to nodes in that file or under
+    /// that directory.
     ///
     /// "Annotation" here is the language-neutral term for Rust attributes
     /// (`#[derive(...)]`, `#[cfg(test)]`), Python decorators (`@pytest.fixture`),
@@ -471,14 +471,14 @@ impl Database {
         path_prefix: Option<&str>,
     ) -> Result<Vec<(String, u64)>> {
         let (sql, args) = if let Some(prefix) = path_prefix {
-            (
+            let mut sql = String::from(
                 "SELECT name, COUNT(*) AS n \
                  FROM nodes \
-                 WHERE kind = 'annotation_usage' AND file_path LIKE ?1 \
-                 GROUP BY name ORDER BY n DESC, name ASC"
-                    .to_string(),
-                libsql::params_from_iter(vec![libsql::Value::Text(format!("{prefix}%"))]),
-            )
+                 WHERE kind = 'annotation_usage' AND ",
+            );
+            push_path_prefix_filter(&mut sql, "", prefix);
+            sql.push_str(" GROUP BY name ORDER BY n DESC, name ASC");
+            (sql, libsql::params_from_iter(Vec::<libsql::Value>::new()))
         } else {
             (
                 "SELECT name, COUNT(*) AS n \
@@ -517,8 +517,8 @@ impl Database {
     /// - `name`: annotation name (`"test"`, `"derive"`, `"cfg"`, etc.). When
     ///   `None`, returns sites for *all* annotations — useful with `path_prefix`
     ///   to enumerate every annotation in a sub-tree.
-    /// - `path_prefix`: restrict to target nodes whose `file_path` starts with
-    ///   this string.
+    /// - `path_prefix`: restrict to target nodes in this file or under this
+    ///   directory.
     /// - `target_kind`: restrict to targets of this kind
     ///   (`"function"`, `"method"`, `"struct"`, `"module"`, …).
     /// - `limit`: cap the number of rows returned (callers typically pass
@@ -546,8 +546,8 @@ impl Database {
             let _ = write!(sql, " AND a.name = ?{}", params.len());
         }
         if let Some(prefix) = path_prefix {
-            params.push(libsql::Value::Text(format!("{prefix}%")));
-            let _ = write!(sql, " AND t.file_path LIKE ?{}", params.len());
+            sql.push_str(" AND ");
+            push_path_prefix_filter(&mut sql, "t.", prefix);
         }
         if let Some(k) = target_kind {
             params.push(libsql::Value::Text(k.to_string()));
@@ -795,9 +795,9 @@ impl Database {
             param_idx += 1;
         }
         if let Some(prefix) = path_prefix {
-            conditions.push(format!("n.file_path LIKE ?{param_idx}"));
-            param_values.push(libsql::Value::Text(format!("{prefix}%")));
-            param_idx += 1;
+            let mut filter = String::new();
+            push_path_prefix_filter(&mut filter, "n.", prefix);
+            conditions.push(filter);
         }
 
         let where_clause = conditions.join(" AND ");
@@ -862,9 +862,9 @@ impl Database {
             param_idx += 1;
         }
         if let Some(prefix) = path_prefix {
-            conditions.push(format!("file_path LIKE ?{param_idx}"));
-            param_values.push(libsql::Value::Text(format!("{prefix}%")));
-            param_idx += 1;
+            let mut filter = String::new();
+            push_path_prefix_filter(&mut filter, "", prefix);
+            conditions.push(filter);
         }
 
         let where_clause = if conditions.is_empty() {
@@ -1082,28 +1082,17 @@ impl Database {
         &self,
         path_prefix: Option<&str>,
     ) -> Result<Vec<(String, String, u64)>> {
-        let (sql, param_values): (&str, Vec<libsql::Value>) = match path_prefix {
-            Some(prefix) => (
-                "SELECT file_path, kind, COUNT(*) AS cnt
-                 FROM nodes
-                 WHERE file_path LIKE ?1
-                 GROUP BY file_path, kind
-                 ORDER BY file_path, cnt DESC",
-                vec![libsql::Value::Text(format!("{prefix}%"))],
-            ),
-            None => (
-                "SELECT file_path, kind, COUNT(*) AS cnt
-                 FROM nodes
-                 GROUP BY file_path, kind
-                 ORDER BY file_path, cnt DESC",
-                vec![],
-            ),
-        };
+        let mut sql = String::from("SELECT file_path, kind, COUNT(*) AS cnt FROM nodes");
+        if let Some(prefix) = path_prefix {
+            sql.push_str(" WHERE ");
+            push_path_prefix_filter(&mut sql, "", prefix);
+        }
+        sql.push_str(" GROUP BY file_path, kind ORDER BY file_path, cnt DESC");
 
         let op = "get_node_distribution";
         let mut rows = self
             .conn()
-            .query(sql, libsql::params_from_iter(param_values))
+            .query(&sql, ())
             .await
             .map_err(|e| TokenSaveError::Database {
                 message: format!("failed to query node distribution: {e}"),
@@ -1139,13 +1128,15 @@ impl Database {
     pub async fn get_call_edges(&self, path_prefix: Option<&str>) -> Result<Vec<(String, String)>> {
         let op = "get_call_edges";
         let (sql, param_values): (String, Vec<libsql::Value>) = match path_prefix {
-            Some(prefix) => (
-                "SELECT e.source, e.target FROM edges e
+            Some(prefix) => {
+                let mut sql = String::from(
+                    "SELECT e.source, e.target FROM edges e
                  JOIN nodes n ON e.source = n.id
-                 WHERE e.kind = 'calls' AND n.file_path LIKE ?1"
-                    .to_string(),
-                vec![libsql::Value::Text(format!("{prefix}%"))],
-            ),
+                 WHERE e.kind = 'calls' AND ",
+                );
+                push_path_prefix_filter(&mut sql, "n.", prefix);
+                (sql, vec![])
+            }
             None => (
                 "SELECT source, target FROM edges WHERE kind = 'calls'".to_string(),
                 vec![],
@@ -1188,13 +1179,15 @@ impl Database {
     ) -> Result<Vec<(String, String, Option<u32>)>> {
         let op = "get_call_edges_with_lines";
         let (sql, param_values): (String, Vec<libsql::Value>) = match path_prefix {
-            Some(prefix) => (
-                "SELECT e.source, e.target, e.line FROM edges e
+            Some(prefix) => {
+                let mut sql = String::from(
+                    "SELECT e.source, e.target, e.line FROM edges e
                  JOIN nodes n ON e.source = n.id
-                 WHERE e.kind = 'calls' AND n.file_path LIKE ?1"
-                    .to_string(),
-                vec![libsql::Value::Text(format!("{prefix}%"))],
-            ),
+                 WHERE e.kind = 'calls' AND ",
+                );
+                push_path_prefix_filter(&mut sql, "n.", prefix);
+                (sql, vec![])
+            }
             None => (
                 "SELECT source, target, line FROM edges WHERE kind = 'calls'".to_string(),
                 vec![],
@@ -1256,9 +1249,9 @@ impl Database {
             }
         }
         if let Some(prefix) = path_prefix {
-            conditions.push(format!("n.file_path LIKE ?{param_idx}"));
-            param_values.push(libsql::Value::Text(format!("{prefix}%")));
-            param_idx += 1;
+            let mut filter = String::new();
+            push_path_prefix_filter(&mut filter, "n.", prefix);
+            conditions.push(filter);
         }
 
         let where_clause = conditions.join(" AND ");
@@ -1339,8 +1332,13 @@ impl Database {
             'case_class', 'kotlin_object', 'inner_class', 'abstract_method', 'constructor', \
             'struct_method', 'val', 'var', 'mixin', 'extension', 'union', 'typedef'";
 
-        let (sql, param_values): (String, Vec<libsql::Value>) = match path_prefix {
-            Some(prefix) => (
+        let path_filter = path_prefix.map(|prefix| {
+            let mut filter = String::new();
+            push_path_prefix_filter(&mut filter, "", prefix);
+            filter
+        });
+        let (sql, param_values): (String, Vec<libsql::Value>) = match &path_filter {
+            Some(path_filter) => (
                 format!(
                     "SELECT id, kind, name, qualified_name, file_path,
                             start_line, end_line, start_column, end_column,
@@ -1349,14 +1347,11 @@ impl Database {
                      WHERE visibility = 'public'
                        AND (docstring IS NULL OR docstring = '')
                        AND kind IN ({DOC_COVERAGE_KINDS})
-                       AND file_path LIKE ?1
+                       AND {path_filter}
                      ORDER BY file_path, start_line
-                     LIMIT ?2"
+                     LIMIT ?1"
                 ),
-                vec![
-                    libsql::Value::Text(format!("{prefix}%")),
-                    libsql::Value::Integer(limit as i64),
-                ],
+                vec![libsql::Value::Integer(limit as i64)],
             ),
             None => (
                 format!(

--- a/src/db/queries/metadata.rs
+++ b/src/db/queries/metadata.rs
@@ -47,9 +47,9 @@ impl Database {
         Ok(())
     }
 
-    /// Returns all nodes under a directory prefix filtered by kinds.
+    /// Returns all nodes in a file or under a directory, filtered by kinds.
     ///
-    /// Uses `LIKE dir || '%'` for the path prefix and an `IN` clause for kinds.
+    /// Uses the shared escaped path filter and an `IN` clause for kinds.
     pub async fn get_nodes_by_dir(&self, dir: &str, kinds: &[NodeKind]) -> Result<Vec<Node>> {
         if kinds.is_empty() {
             return Ok(Vec::new());
@@ -58,8 +58,10 @@ impl Database {
         let kind_placeholders: Vec<String> = kinds
             .iter()
             .enumerate()
-            .map(|(i, _)| format!("?{}", i + 2))
+            .map(|(i, _)| format!("?{}", i + 1))
             .collect();
+        let mut path_filter = String::new();
+        push_path_prefix_filter(&mut path_filter, "", dir);
         let sql = format!(
             "SELECT id, kind, name, qualified_name, file_path,
                     start_line, end_line, start_column, end_column,
@@ -67,13 +69,12 @@ impl Database {
                     branches, loops, returns, max_nesting,
                     unsafe_blocks, unchecked_calls, assertions, updated_at, attrs_start_line, parent_id, cognitive_complexity, distinct_operators, distinct_operands, total_operators, total_operands
              FROM nodes
-             WHERE file_path LIKE ?1 || '%' AND kind IN ({})
+             WHERE {path_filter} AND kind IN ({})
              ORDER BY file_path, start_line",
             kind_placeholders.join(", ")
         );
 
         let mut param_values: Vec<libsql::Value> = Vec::new();
-        param_values.push(libsql::Value::Text(dir.to_string()));
         for k in kinds {
             param_values.push(libsql::Value::Text(k.as_str().to_string()));
         }

--- a/src/mcp/tools/definitions.rs
+++ b/src/mcp/tools/definitions.rs
@@ -1099,7 +1099,7 @@ fn def_distribution() -> ToolDefinition {
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "Directory or file path prefix to filter (e.g. 'src/main/java/com/example'). Omit for entire codebase."
+                    "description": "File or directory to filter to (e.g. 'src/main/java/com/example'). Omit for entire codebase."
                 },
                 "summary": {
                     "type": "boolean",
@@ -1166,7 +1166,7 @@ fn def_doc_coverage() -> ToolDefinition {
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "Directory or file path prefix to filter (e.g. 'src/main'). Omit for entire codebase."
+                    "description": "File or directory to filter to (e.g. 'src/main'). Omit for entire codebase."
                 },
                 "limit": {
                     "type": "number",
@@ -1230,11 +1230,11 @@ fn def_port_status() -> ToolDefinition {
             "properties": {
                 "source_dir": {
                     "type": "string",
-                    "description": "Path prefix for source code (e.g. 'src/python/')"
+                    "description": "Directory holding the source code (e.g. 'src/python/')"
                 },
                 "target_dir": {
                     "type": "string",
-                    "description": "Path prefix for target code (e.g. 'src/rust/')"
+                    "description": "Directory holding the target code (e.g. 'src/rust/')"
                 },
                 "kinds": {
                     "type": "array",
@@ -1257,7 +1257,7 @@ fn def_port_order() -> ToolDefinition {
             "properties": {
                 "source_dir": {
                     "type": "string",
-                    "description": "Path prefix for source code (e.g. 'src/python/')"
+                    "description": "Directory holding the source code (e.g. 'src/python/')"
                 },
                 "kinds": {
                     "type": "array",
@@ -1763,7 +1763,7 @@ fn def_annotations() -> ToolDefinition {
                 },
                 "file": {
                     "type": "string",
-                    "description": "Restrict to target nodes whose file_path starts with this prefix (file or directory)."
+                    "description": "Restrict to target nodes in this file or under this directory."
                 },
                 "target_kind": {
                     "type": "string",

--- a/tests/path_prefix_like_escape_test.rs
+++ b/tests/path_prefix_like_escape_test.rs
@@ -1,23 +1,27 @@
-//! `--path` scoping in `coupling`, `inheritance_depth` and `god_class` — #524.
+//! `LIKE` escaping in every query that scopes by a caller's path: #524 and the
+//! sweep after it.
 //!
-//! These three queries built their path filter by interpolating the caller's
-//! path straight into the SQL string, where every sibling query binds or
-//! quote-escapes it. Three consequences, all silent: `_` and `%` acted as
-//! `LIKE` wildcards, so a filter for `src/my_mod` also matched `src/myXmod`
-//! and `src/%` matched everything; and a path containing `'` closed the
-//! literal and failed the query outright.
+//! #524: `coupling`, `inheritance_depth` and `god_class` interpolated the
+//! caller's path straight into the SQL string. Ten more queries bound it as a
+//! parameter, `format!("{prefix}%")`, which closes the apostrophe but leaves
+//! `_` and `%` live as `LIKE` wildcards. The wildcard consequences were silent
+//! either way: a filter for `src/my_mod` also matched `src/myXmod` and `src/%`
+//! matched everything. In the interpolated three, a path containing `'` also
+//! closed the literal and failed the query outright.
 //!
-//! Escaping alone is not enough to catch this — binding a parameter fixes the
-//! apostrophe and leaves both wildcards live — so each case below is asserted
-//! separately against all three queries.
+//! Binding a parameter fixes only the apostrophe, so each case below is
+//! asserted separately against every one of these queries.
 
+use serde_json::json;
 use tempfile::tempdir;
+use tokensave::mcp::handle_tool_call;
 use tokensave::tokensave::TokenSave;
+use tokensave::types::{EdgeKind, NodeKind};
 
 /// Two sibling directories whose names differ only where `LIKE` would treat
 /// `_` as a wildcard, plus one holding an apostrophe. Each carries a small
-/// class hierarchy with a cross-file reference, so all three queries under
-/// test have rows to return.
+/// class hierarchy with a cross-file reference, a recursive function, and
+/// annotated Rust and Java code, so every query under test has rows to return.
 async fn indexed() -> (tempfile::TempDir, TokenSave) {
     let tmp = tempdir().unwrap();
     let root = tmp.path();
@@ -34,6 +38,21 @@ async fn indexed() -> (tempfile::TempDir, TokenSave) {
             "from .base import Base\n\n\nclass Middle(Base):\n    def run(self):\n        return Base.run(self)\n\n\nclass Leaf(Middle):\n    def go(self):\n        return self.run()\n",
         )
         .unwrap();
+        std::fs::write(
+            root.join(dir).join("walk.py"),
+            "def walk(n):\n    if n <= 0:\n        return 0\n    return walk(n - 1)\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join(dir).join("point.rs"),
+            "#[inline]\npub fn fact(n: u64) -> u64 {\n    if n == 0 { 1 } else { n * fact(n - 1) }\n}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join(dir).join("Svc.java"),
+            "package demo;\n\npublic class Svc {\n    @Deprecated\n    public void old() {\n    }\n}\n",
+        )
+        .unwrap();
     }
 
     let cg = TokenSave::init(root).await.unwrap();
@@ -41,7 +60,19 @@ async fn indexed() -> (tempfile::TempDir, TokenSave) {
     (tmp, cg)
 }
 
-/// Every path the three queries return for `path_prefix`, as plain strings.
+/// The file each call edge starts in. The two call-edge queries return node
+/// ids rather than paths, and they scope on the source node.
+async fn source_paths(cg: &TokenSave, ids: Vec<String>) -> Vec<String> {
+    cg.db()
+        .get_nodes_by_ids(&ids)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|node| node.file_path)
+        .collect()
+}
+
+/// Every path each scoped query returns for `path_prefix`, as plain strings.
 async fn scoped_paths(cg: &TokenSave, prefix: &str) -> Vec<(&'static str, Vec<String>)> {
     let coupling = cg
         .db()
@@ -70,10 +101,110 @@ async fn scoped_paths(cg: &TokenSave, prefix: &str) -> Vec<(&'static str, Vec<St
         .map(|(node, _, _, _)| node.file_path)
         .collect();
 
+    let rank = cg
+        .db()
+        .get_ranked_nodes_by_edge_kind(&EdgeKind::Calls, None, true, Some(prefix), 100)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|(node, _)| node.file_path)
+        .collect();
+
+    let largest = cg
+        .db()
+        .get_largest_nodes(None, Some(prefix), 100)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|(node, _)| node.file_path)
+        .collect();
+
+    let distribution = cg
+        .db()
+        .get_node_distribution(Some(prefix))
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|(path, _, _)| path)
+        .collect();
+
+    let call_edge_sources = cg
+        .db()
+        .get_call_edges(Some(prefix))
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|(source, _)| source)
+        .collect();
+    let call_edges = source_paths(cg, call_edge_sources).await;
+
+    let lined_call_edge_sources = cg
+        .db()
+        .get_call_edges_with_lines(Some(prefix))
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|(source, _, _)| source)
+        .collect();
+    let call_edges_with_lines = source_paths(cg, lined_call_edge_sources).await;
+
+    let complexity = cg
+        .db()
+        .get_complexity_ranked(None, Some(prefix), 100)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|(node, _, _, _, _)| node.file_path)
+        .collect();
+
+    let undocumented = cg
+        .db()
+        .get_undocumented_public_symbols(Some(prefix), 100)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|node| node.file_path)
+        .collect();
+
+    let annotation_sites = cg
+        .db()
+        .get_annotation_sites(None, Some(prefix), None, 100)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|site| {
+            site["target"]["file"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string()
+        })
+        .collect();
+
+    let nodes_by_dir = cg
+        .db()
+        .get_nodes_by_dir(
+            prefix,
+            &[NodeKind::Function, NodeKind::Method, NodeKind::Class],
+        )
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|node| node.file_path)
+        .collect();
+
     vec![
         ("coupling", coupling),
         ("inheritance_depth", inheritance),
         ("god_class", god),
+        ("rank", rank),
+        ("largest", largest),
+        ("distribution", distribution),
+        ("call_edges", call_edges),
+        ("call_edges_with_lines", call_edges_with_lines),
+        ("complexity", complexity),
+        ("doc_coverage", undocumented),
+        ("annotation_sites", annotation_sites),
+        ("nodes_by_dir", nodes_by_dir),
     ]
 }
 
@@ -127,8 +258,23 @@ async fn percent_in_a_path_is_not_a_wildcard() {
     }
 }
 
+/// A path names a file or a directory, never a leading fragment of one. The
+/// filter used to be a plain string prefix, so `src/my` also matched
+/// `src/my_mod` and `src/myXmod`.
+#[tokio::test]
+async fn a_partial_directory_name_matches_nothing() {
+    let (_tmp, cg) = indexed().await;
+
+    for (query, paths) in scoped_paths(&cg, "src/my").await {
+        assert!(
+            paths.is_empty(),
+            "{query} matched `src/my` as a string prefix: {paths:?}"
+        );
+    }
+}
+
 /// A path containing `'` must be quoted, not close the SQL literal. Before
-/// the fix each of these failed with a SQLite syntax error.
+/// the fix the three interpolated queries failed with a SQLite syntax error.
 #[tokio::test]
 async fn an_apostrophe_in_a_path_does_not_break_the_query() {
     let (_tmp, cg) = indexed().await;
@@ -141,6 +287,88 @@ async fn an_apostrophe_in_a_path_does_not_break_the_query() {
         assert!(
             paths.iter().all(|p| p.starts_with("src/it's/")),
             "{query} leaked outside the apostrophe directory: {paths:?}"
+        );
+    }
+}
+
+/// The annotation histogram returns counts, not paths, so its scoping is
+/// checked by count. Every directory holds the same files, so a correctly
+/// scoped path counts exactly what the control directory counts.
+#[tokio::test]
+async fn annotation_histogram_counts_only_the_requested_directory() {
+    let (_tmp, cg) = indexed().await;
+    let total = |hist: Vec<(String, u64)>| -> u64 { hist.into_iter().map(|(_, n)| n).sum() };
+
+    let control = total(
+        cg.db()
+            .get_annotation_histogram(Some("src/myXmod"))
+            .await
+            .unwrap(),
+    );
+    assert!(
+        control > 0,
+        "the fixture produces no annotations in the control directory"
+    );
+
+    for prefix in ["src/my_mod", "src/it's"] {
+        let counted = total(
+            cg.db()
+                .get_annotation_histogram(Some(prefix))
+                .await
+                .unwrap(),
+        );
+        assert_eq!(
+            counted, control,
+            "the histogram for {prefix} counted annotations outside that directory"
+        );
+    }
+
+    let percent = total(
+        cg.db()
+            .get_annotation_histogram(Some("src/%"))
+            .await
+            .unwrap(),
+    );
+    assert_eq!(percent, 0, "`%` acted as a wildcard in the histogram");
+}
+
+/// With no `path` argument the listing tools fall back to the directory the
+/// server was launched from. That value reaches the same queries, so a server
+/// started inside `svc/user_api` must not answer with `svc/userXapi`, even
+/// though the agent passed no path at all.
+#[tokio::test]
+async fn a_launch_directory_scope_is_not_a_wildcard() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    for (dir, class) in [("svc/user_api", "UserApi"), ("svc/userXapi", "UserXapi")] {
+        std::fs::create_dir_all(root.join(dir)).unwrap();
+        std::fs::write(
+            root.join(dir).join("api.py"),
+            format!("class {class}:\n    def handle(self):\n        return 1\n"),
+        )
+        .unwrap();
+    }
+    let cg = TokenSave::init(root).await.unwrap();
+    cg.sync().await.unwrap();
+
+    // The control first: a scope with no metacharacter.
+    for (scope, sibling) in [
+        ("svc/userXapi", "svc/user_api/"),
+        ("svc/user_api", "svc/userXapi/"),
+    ] {
+        let result = handle_tool_call(&cg, "tokensave_largest", json!({}), None, Some(scope))
+            .await
+            .unwrap();
+        let text = result.value["content"][0]["text"]
+            .as_str()
+            .unwrap_or_default();
+        assert!(
+            text.contains(&format!("{scope}/")),
+            "largest scoped to {scope} returned nothing from it: {text}"
+        );
+        assert!(
+            !text.contains(sibling),
+            "largest scoped to {scope} leaked into {sibling}: {text}"
         );
     }
 }

--- a/tests/tokensave_test.rs
+++ b/tests/tokensave_test.rs
@@ -955,15 +955,23 @@ async fn test_get_undocumented_public_symbols_no_filter() {
 #[tokio::test]
 async fn test_get_undocumented_public_symbols_with_prefix() {
     let (_dir, cg) = setup().await;
+    // The filter names a file or a directory, not a string prefix, so the
+    // file is named in full: `src/utils` would match neither.
     let undoc = cg
-        .get_undocumented_public_symbols(Some("src/utils"), 50)
+        .get_undocumented_public_symbols(Some("src/utils.rs"), 50)
         .await
         .unwrap();
     // helper in utils.rs is pub without docs
+    let names: Vec<&str> = undoc.iter().map(|n| n.name.as_str()).collect();
+    assert!(
+        names.contains(&"helper"),
+        "helper is pub without docs, should appear, found: {:?}",
+        names,
+    );
     for node in &undoc {
-        assert!(
-            node.file_path.starts_with("src/utils"),
-            "path prefix filter should only return src/utils files, got: {}",
+        assert_eq!(
+            node.file_path, "src/utils.rs",
+            "path filter should only return src/utils.rs, got: {}",
             node.file_path,
         );
     }


### PR DESCRIPTION
## Summary

- Escape the path filter in the ten queries #524 left out, by routing them through the same `push_path_prefix_filter` the #524 fix introduced.
- Before this, nine MCP tools returned a sibling directory for a path containing `_`, and every directory for `src/%`. That also happened with no `path` argument, through the directory the server was launched from.

## Motivation

Follow-up to [your note on #524](https://github.com/aovestdipaperino/tokensave/issues/524#issuecomment-5638372903) that the remaining `LIKE ?N` sites taking a user path are "a real and separate gap" that "deserves its own issue". This is that gap, with the fix attached.

On master (`68086de`), in a tree with `src/my_mod`, `src/myXmod` and `src/it's`, two runs each through `tokensave tool` (`annotations` takes the path as `file`, `port_status` and `port_order` as `source_dir` and `target_dir`):

| path | `rank`, `largest`, `distribution`, `recursion`, `complexity`, `doc_coverage`, `annotations`, `port_status`, `port_order` |
|---|---|
| `src/myXmod` (control) | only `src/myXmod` |
| `src/my_mod` | also `src/myXmod` |
| `src/%` | every directory |
| `src/my` | `src/my_mod` and `src/myXmod` |
| `src/it's` | correct, since these queries bind the value |

With no `path`, these tools fall back to the directory the server was launched from. A `serve` started in `svc/user_api` answered `largest` with `svc/userXapi` too.

## Changes

- `src/db/queries/edges.rs` and `metadata.rs`: `get_annotation_histogram`, `get_annotation_sites`, `get_ranked_nodes_by_edge_kind`, `get_largest_nodes`, `get_node_distribution`, `get_call_edges`, `get_call_edges_with_lines`, `get_complexity_ranked`, `get_undocumented_public_symbols` and `get_nodes_by_dir` now use `push_path_prefix_filter`. Bound parameters after the removed one are renumbered. `get_call_edges` has no caller outside the tests; I changed it anyway so no unescaped copy is left.
- **Behaviour change**, the same one #524 made for its three queries: the filter matches a file or a directory, not a string prefix, so `src/my` no longer matches `src/my_mod`. One existing test relied on the old behaviour. `test_get_undocumented_public_symbols_with_prefix` passed `src/utils` to mean the file `src/utils.rs`; after this change that returns nothing, and the test would still have passed because it only checked each returned row. It now names the file and asserts `helper` is returned.
- `src/mcp/tools/definitions.rs`: the six parameter descriptions that said "prefix" now say file or directory.
- `tests/path_prefix_like_escape_test.rs`: the four existing cases now run against twelve of the thirteen path-filtered queries. The thirteenth, the annotation histogram, returns counts rather than paths, so it gets its own count-based test. Also added a partial-name test and a launch-directory test through `handle_tool_call` with a scope prefix.
- `CHANGELOG.md` under `[Unreleased]`.

Left out on purpose: `get_nodes_by_qualified_name` (`%::{qname}`) and the search fallback (`%{query}%`) also leave `_` live, but they match names rather than paths, so they belong to a different change.

## Test plan

All on macOS arm64, rustc 1.95.0 (the repository's `rust-toolchain.toml`), default features.

- [x] `cargo test --workspace`: 3,868 passed, 0 failed, same result on two runs (176 test binaries). Master: 3,865 passed, 0 failed, the same under `cargo test` and `cargo test --workspace`.
- [x] `cargo clippy --workspace --all-targets`: no new warnings. Master and this branch both report the same 5 warnings (two unknown-lint warnings in `src/mcp/transport.rs`, three missing-backtick doc warnings); two of them sit 5 lines higher in `edges.rs` because the file got shorter.
- [x] `cargo fmt --all -- --check`
- [x] The new tests against unmodified master: 5 of the 7 tests in `path_prefix_like_escape_test.rs` fail (`_`, `%`, the histogram count, the partial name, the launch directory), and the control and apostrophe cases pass.
- [x] Tested manually: the table above re-run with a build of this branch, and the `serve` launch-directory case, two runs each: for `src/myXmod`, `src/my_mod` and `src/it's` every tool returned only that directory, and for `src/%` and `src/my` it returned nothing (histogram counts 4, 4, 4, 0, 0). The server launched in `svc/user_api` answered only with `svc/user_api`. Both runs were identical.

## Checklist

- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [x] No secrets, credentials, or `.env` files included
- [x] Breaking changes documented: the file-or-directory matching described above
