### PR TITLE
ci: strengthen concurrency, MSRV verification, and compiler bounds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,17 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: "2"
+  RUST_TEST_THREADS: "2"
 
 jobs:
   test:
@@ -68,6 +74,15 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --workspace --all-targets
+
+  msrv:
+    name: MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check --workspace --locked
 
   fmt:
     name: Format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
   msrv:
     name: MSRV
     runs-on: ubuntu-latest
+    env:
+      RUSTUP_TOOLCHAIN: "1.95.0"
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.95.0


### PR DESCRIPTION
## Summary

- Add workflow-level cancellation for superseded CI runs.
- Add an MSRV check for Rust 1.95.0.
- Bound compiler and test parallelism to stabilize hosted runners.

## Motivation

CI currently allows redundant runs to consume runner capacity, does not enforce the declared MSRV, and can use excessive memory and disk during concurrent compilation and testing. Refs #557.

## Changes

- Add `ci-${{ github.workflow }}-${{ github.ref }}` concurrency with `cancel-in-progress: true`.
- Set `CARGO_BUILD_JOBS` and `RUST_TEST_THREADS` to `2` at workflow scope.
- Add an `msrv` job using `dtolnay/rust-toolchain@1.95.0`, an explicit `RUSTUP_TOOLCHAIN` override, and `cargo check --workspace --locked`.
- Keep the change limited to CI configuration; this branch does not update the local toolchain or `Cargo.toml`.

## Test plan

- [x] Workflow YAML parses locally.
- [x] GitHub Actions CI passes on the upstream pull request: Linux, macOS, Windows, Clippy, MSRV, and Format.
- [x] `cargo test` passes in GitHub Actions.
- [x] `cargo clippy` has no new warnings in GitHub Actions.
- [x] Tested manually (not applicable to this CI-only change).

## Checklist

- [x] `CHANGELOG.md` updated (not user-facing)
- [x] No secrets, credentials, or `.env` files included
- [x] Breaking changes documented (if any)
